### PR TITLE
Integrate PRs from aleph-parachain-bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,20 +14,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli 0.26.2",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.2",
+ "gimli",
 ]
 
 [[package]]
@@ -42,7 +33,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -51,18 +42,18 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "aead"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -90,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
@@ -115,12 +106,12 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
- "aead 0.5.1",
- "aes 0.8.2",
+ "aead 0.5.2",
+ "aes 0.8.3",
  "cipher 0.4.4",
  "ctr 0.9.2",
  "ghash 0.5.0",
@@ -153,7 +144,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -165,7 +156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -175,6 +166,15 @@ name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -258,22 +258,18 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.3.4",
  "log",
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-bridge-aleph",
  "pallet-collator-selection",
- "pallet-multisig",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "pallet-utility",
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
@@ -300,9 +296,15 @@ dependencies = [
 
 [[package]]
 name = "always-assert"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf688625d06217d5b1bb0ea9d9c44a1635fd0ee3534466388d18203174f4d11"
+checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -373,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "approx"
@@ -400,9 +402,9 @@ checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
 name = "array-bytes"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f72e9d6fac4bc80778ea470b20197b88d28c292bb7d60c3fb099280003cd19"
+checksum = "d9b1c5a481ec30a5abd8dfbd94ab5cf1bb4e9a66be7f1b3b322f2f1170c200fd"
 
 [[package]]
 name = "arrayref"
@@ -418,9 +420,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asn1-rs"
@@ -435,7 +437,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -451,7 +453,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -490,12 +492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1_der"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,22 +510,22 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock",
  "autocfg",
+ "cfg-if",
  "concurrent-queue",
  "futures-lite",
- "libc",
  "log",
  "parking",
  "polling",
+ "rustix 0.37.20",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -542,14 +538,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.67"
+name = "async-recursion"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -567,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-waker"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "atty"
@@ -594,12 +601,12 @@ version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
- "addr2line 0.19.0",
+ "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
- "object 0.30.3",
+ "miniz_oxide 0.6.2",
+ "object",
  "rustc-demangle",
 ]
 
@@ -616,10 +623,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
-name = "base58"
+name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -629,9 +636,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -651,7 +658,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "hash-db",
  "log",
@@ -668,22 +675,23 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "peeking_take_while",
+ "prettyplease 0.2.9",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -691,6 +699,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
 
 [[package]]
 name = "bitvec"
@@ -710,7 +724,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -720,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
+ "arrayvec 0.7.4",
  "constant_time_eq",
 ]
 
@@ -731,22 +745,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
+ "arrayvec 0.7.4",
  "constant_time_eq",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
+checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
+ "arrayvec 0.7.4",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -767,7 +781,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -776,7 +790,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -806,9 +820,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a071c348a5ef6da1d3a87166b408170b46002382b1dda83992b5c2208cefb370"
+checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -826,6 +840,134 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-aleph-header-chain"
+version = "0.1.0"
+dependencies = [
+ "bp-header-chain",
+ "bp-runtime",
+ "bp-test-utils",
+ "frame-support",
+ "hex",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-header-chain"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/parity-bridges-common?rev=9afb6d15#9afb6d1506ab5b012a8dcf825703d515a33220ab"
+dependencies = [
+ "bp-runtime",
+ "finality-grandpa",
+ "frame-support",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-messages"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/parity-bridges-common?rev=9afb6d15#9afb6d1506ab5b012a8dcf825703d515a33220ab"
+dependencies = [
+ "bp-header-chain",
+ "bp-runtime",
+ "frame-support",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-parachains"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/parity-bridges-common?rev=9afb6d15#9afb6d1506ab5b012a8dcf825703d515a33220ab"
+dependencies = [
+ "bp-header-chain",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "frame-support",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-polkadot-core"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/parity-bridges-common?rev=9afb6d15#9afb6d1506ab5b012a8dcf825703d515a33220ab"
+dependencies = [
+ "bp-messages",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "bp-runtime"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/parity-bridges-common?rev=9afb6d15#9afb6d1506ab5b012a8dcf825703d515a33220ab"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "hash-db",
+ "impl-trait-for-tuples",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "trie-db",
+]
+
+[[package]]
+name = "bp-test-utils"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/parity-bridges-common?rev=9afb6d15#9afb6d1506ab5b012a8dcf825703d515a33220ab"
+dependencies = [
+ "bp-header-chain",
+ "bp-parachains",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "ed25519-dalek",
+ "finality-grandpa",
+ "parity-scale-codec",
+ "sp-application-crypto",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,9 +975,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
  "serde",
@@ -852,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byte-slice-cast"
@@ -917,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -960,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.10.3"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
+checksum = "215c0072ecc28f92eeb0eea38ba63ddfcb65c2828c46311d646f1a3ff5f9841c"
 dependencies = [
  "smallvec",
 ]
@@ -1006,13 +1148,13 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "time 0.1.45",
  "wasm-bindgen",
@@ -1038,7 +1180,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1047,7 +1189,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1071,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -1082,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1093,26 +1235,27 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
 dependencies = [
  "anstream",
  "anstyle",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1151,9 +1294,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "comfy-table"
-version = "6.1.4"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
+checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
  "strum",
  "strum_macros",
@@ -1161,12 +1304,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.1.0"
+name = "common-path"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1177,9 +1339,9 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "convert_case"
@@ -1199,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core2"
@@ -1233,37 +1395,36 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7379abaacee0f14abf3204a7606118f0465785252169d186337bcb75030815a"
+checksum = "1277fbfa94bc82c8ec4af2ded3e639d49ca5f7f3c7eeab2c66accd135ece4e70"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9489fa336927df749631f1008007ced2871068544f40a202ce6d93fbf2366a7b"
+checksum = "c6e8c31ad3b2270e9aeec38723888fe1b0ace3bea2b06b3f749ccf46661d3220"
 dependencies = [
- "arrayvec 0.7.2",
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.26.2",
- "hashbrown 0.12.3",
+ "gimli",
+ "hashbrown 0.13.2",
  "log",
  "regalloc2",
  "smallvec",
@@ -1272,33 +1433,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bbb67da91ec721ed57cef2f7c5ef7728e1cd9bde9ffd3ef8601022e73e3239"
+checksum = "c8ac5ac30d62b2d66f12651f6b606dbdfd9c2cfd0908de6b387560a277c5c9da"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418ecb2f36032f6665dc1a5e2060a143dbab41d83b784882e97710e890a7a16d"
+checksum = "dd82b8b376247834b59ed9bdc0ddeb50f517452827d4a11bccf5937b213748b8"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf583f7b093f291005f9fb1323e2c37f6ee4c7909e39ce016b2e8360d461705"
+checksum = "40099d38061b37e505e63f89bab52199037a72b931ad4868d9089ff7268660b0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b66bf9e916f57fbbd0f7703ec6286f4624866bf45000111627c70d272c8dda1"
+checksum = "64a25d9d0a0ae3079c463c34115ec59507b4707175454f0eee0891e83e30e82d"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1308,15 +1469,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649782a39ce99798dd6b4029e2bb318a2fbeaade1b4fa25330763c10c65bc358"
+checksum = "80de6a7d0486e4acbd5f9f87ec49912bf4c8fb6aea00087b989685460d4469ba"
 
 [[package]]
 name = "cranelift-native"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "937e021e089c51f9749d09e7ad1c4f255c2f8686cb8c3df63a34b3ec9921bc41"
+checksum = "bb6b03e0e03801c4b3fd8ce0758a94750c07a44e7944cc0ffbf0d3f2e7c79b00"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1325,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.93.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d850cf6775477747c9dfda9ae23355dd70512ffebc70cf82b85a5b111ae668b5"
+checksum = "ff3220489a3d928ad91e59dd7aeaa8b3de18afb554a6211213673a71c90737ac"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1365,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1386,14 +1547,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -1409,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -1428,7 +1589,19 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+dependencies = [
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -1440,7 +1613,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -1451,7 +1624,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
@@ -1461,7 +1634,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
@@ -1486,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1501,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1524,13 +1697,20 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
+ "cumulus-client-collator",
  "cumulus-client-consensus-common",
+ "cumulus-client-consensus-proposer",
  "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-relay-chain-interface",
  "futures",
  "parity-scale-codec",
+ "polkadot-node-primitives",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-aura",
@@ -1546,6 +1726,8 @@ dependencies = [
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
+ "sp-state-machine",
+ "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -1553,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1569,15 +1751,32 @@ dependencies = [
  "schnellru",
  "sp-blockchain",
  "sp-consensus",
+ "sp-core",
  "sp-runtime",
  "sp-trie",
+ "substrate-prometheus-endpoint",
  "tracing",
+]
+
+[[package]]
+name = "cumulus-client-consensus-proposer"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cumulus-primitives-parachain-inherent",
+ "sp-consensus",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "thiserror",
 ]
 
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1600,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1624,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1659,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1675,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1692,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1721,18 +1920,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1746,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1762,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -1783,12 +1982,13 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
  "polkadot-primitives",
+ "scale-info",
  "sp-api",
  "sp-runtime",
  "sp-std",
@@ -1799,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1822,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-primitives-core",
  "futures",
@@ -1835,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1853,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1878,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1896,28 +2096,32 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
- "array-bytes 6.0.0",
+ "array-bytes 6.1.0",
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
  "lru 0.9.0",
+ "polkadot-availability-recovery",
+ "polkadot-collator-protocol",
  "polkadot-core-primitives",
  "polkadot-network-bridge",
+ "polkadot-node-collation-generation",
+ "polkadot-node-core-runtime-api",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "polkadot-service",
  "sc-authority-discovery",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
  "sc-service",
  "sc-tracing",
+ "sc-utils",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
@@ -1930,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1960,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2005,16 +2209,16 @@ dependencies = [
  "cfg-if",
  "fiat-crypto",
  "packed_simd_2",
- "platforms 3.0.2",
+ "platforms",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.93"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+checksum = "e88abab2f5abbe4c56e8f1fb431b784d710b709888f35755a160e62e33fe38e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2024,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.93"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+checksum = "5c0c11acd0e63bae27dcd2afced407063312771212b7a823b4fd72d633be30fb"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2034,24 +2238,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.12",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.93"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+checksum = "8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.93"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+checksum = "a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2091,15 +2295,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+checksum = "c904b33cc60130e1aeea4956ab803d08a3f4a0ca82d64ed757afac3891f2bb99"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2107,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+checksum = "8fdf3fce3ce863539ec1d7fd1b6dcc3c645663376b43ed376bbf887733e4f772"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
@@ -2123,6 +2327,16 @@ checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+dependencies = [
+ "const-oid",
  "zeroize",
 ]
 
@@ -2241,16 +2455,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2298,13 +2513,39 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "docify"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1b04e6ef3d21119d3eb7b032bca17f99fe041e9c072f30f32cc0e1a2b1f3c4"
+dependencies = [
+ "docify_macros",
+]
+
+[[package]]
+name = "docify_macros"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5610df7f2acf89a1bb5d1a66ae56b1c7fcdcfe3948856fb3ace3f644d70eb7"
+dependencies = [
+ "common-path",
+ "derive-syn-parse",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.18",
+ "termcolor",
+ "walkdir",
 ]
 
 [[package]]
@@ -2312,12 +2553,6 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dtoa"
@@ -2358,10 +2593,24 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+dependencies = [
+ "der 0.7.6",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.5",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -2370,7 +2619,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -2413,21 +2662,46 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
- "digest 0.10.6",
- "ff",
- "generic-array 0.14.6",
- "group",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array 0.14.7",
+ "group 0.12.1",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.2",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enum-as-inner"
@@ -2443,22 +2717,22 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75d4cd21b95383444831539909fbb14b9dc3fdceb2a6f5d36577329a1f55ccb"
+checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2469,7 +2743,7 @@ checksum = "48016319042fb7c87b78d2993084a831793a897a5cd1a2a67cab9d1eeb4b7d76"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2506,13 +2780,13 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2523,6 +2797,33 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
 ]
 
 [[package]]
@@ -2562,20 +2863,19 @@ dependencies = [
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
 name = "expander"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f360349150728553f92e4c997a16af8915f418d3a0f21b440d34c5632f16ed84"
+checksum = "5f86a749cf851891866c10515ef6c299b5c69661465e9c3bbe7e07a2b77fb0f7"
 dependencies = [
  "blake2",
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2644,10 +2944,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.1.19"
+name = "ff"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "file-per-thread-logger"
@@ -2661,14 +2971,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
- "windows-sys 0.45.0",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2707,13 +3017,13 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2734,16 +3044,16 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -2757,7 +3067,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2782,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -2829,18 +3139,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2857,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2873,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6bb8542ef006ef0de09a5c4420787d79823c0ed7924225822362fd2bf2ff2d"
+checksum = "878babb0b136e731cc77ec2fd883ff02745ff21e6fb662729953d44923df009c"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -2886,31 +3196,37 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
+ "async-recursion",
  "futures",
+ "indicatif",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "spinners",
  "substrate-rpc-client",
  "tokio",
+ "tokio-retry",
 ]
 
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "environmental",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
  "log",
+ "macro_magic",
  "once_cell",
  "parity-scale-codec",
  "paste",
@@ -2921,6 +3237,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-core-hashing-proc-macro",
+ "sp-debug-derive",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
@@ -2935,45 +3252,49 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
+ "expander 2.0.0",
  "frame-support-procedural-tools",
  "itertools",
+ "macro_magic",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
+ "cfg-if",
  "frame-support",
  "log",
  "parity-scale-codec",
@@ -2990,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3005,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3014,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3041,13 +3362,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea55201cc351fdb478217c0fb641b59813da9b4efe4c414a9d8f989a657d149"
+checksum = "7672706608ecb74ab2e055c68327ffc25ae4cac1e12349204fd5fb0f3487cce2"
 dependencies = [
- "libc",
- "rustix 0.35.13",
- "winapi",
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3058,9 +3378,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3073,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3083,15 +3403,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3101,15 +3421,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -3122,13 +3442,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3144,15 +3464,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -3162,9 +3482,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3198,12 +3518,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3229,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3255,25 +3576,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
  "opaque-debug 0.3.0",
- "polyval 0.6.0",
+ "polyval 0.6.1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -3287,7 +3602,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log",
@@ -3300,16 +3615,27 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -3326,9 +3652,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.6"
+version = "4.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
+checksum = "83c3372087601b532857d332f5957cbae686da52bb7810bf038c3e3c3cc2fa0d"
 dependencies = [
  "log",
  "pest",
@@ -3414,6 +3740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3448,7 +3780,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3458,7 +3790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "hmac 0.8.1",
 ]
 
@@ -3521,9 +3853,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3536,7 +3868,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.9",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -3555,31 +3887,46 @@ dependencies = [
  "rustls 0.20.8",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.21.2",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows 0.46.0",
+ "windows 0.48.0",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -3601,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -3621,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7abdbb86e485125dad06c2691e1e393bf3b08c7b743b43aa162a00fd39062e"
+checksum = "a9465340214b296cd17a0009acdb890d6160010b8adf8f78a00d0d7ab270f79f"
 dependencies = [
  "async-io",
  "core-foundation",
@@ -3648,6 +3995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3669,13 +4025,26 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff8cc23a7393a397ed1d7f56e6365cba772aba9f9912ab968b03043c395d057"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3684,7 +4053,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -3732,19 +4101,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3755,32 +4118,32 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.3",
  "widestring",
- "winapi",
+ "windows-sys 0.48.0",
  "winreg",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes 1.0.9",
- "rustix 0.36.11",
- "windows-sys 0.45.0",
+ "io-lifetimes",
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3809,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3823,6 +4186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
  "jsonrpsee-core",
+ "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
@@ -3845,7 +4209,7 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tracing",
  "webpki-roots",
@@ -3858,7 +4222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.2",
+ "arrayvec 0.7.4",
  "async-lock",
  "async-trait",
  "beef",
@@ -3874,6 +4238,25 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
+dependencies = [
+ "async-trait",
+ "hyper",
+ "hyper-rustls 0.23.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustc-hash",
+ "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -3942,29 +4325,30 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "sha2 0.10.6",
+ "ecdsa 0.16.7",
+ "elliptic-curve 0.13.5",
+ "once_cell",
+ "sha2 0.10.7",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "kusama-runtime"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -3975,7 +4359,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.4.1",
  "kusama-runtime-constants",
  "log",
  "pallet-authority-discovery",
@@ -3997,6 +4381,7 @@ dependencies = [
  "pallet-im-online",
  "pallet-indices",
  "pallet-membership",
+ "pallet-message-queue",
  "pallet-multisig",
  "pallet-nis",
  "pallet-nomination-pools",
@@ -4061,8 +4446,8 @@ dependencies = [
 
 [[package]]
 name = "kusama-runtime-constants"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -4094,9 +4479,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2182b8219fee6bd83aacaab7344e840179ae079d5216aa4e249b4d704646a844"
+checksum = "b644c70b92285f66bfc2032922a79000ea30af7bc2ab31902992a5dcb9b434f6"
 dependencies = [
  "kvdb",
  "num_cpus",
@@ -4120,9 +4505,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -4141,29 +4526,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
-name = "libm"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
 name = "libp2p"
-version = "0.50.1"
+version = "0.51.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7b0104790be871edcf97db9bd2356604984e623a08d825c3f27852290266b8"
+checksum = "f210d259724eae82005b5c48078619b7745edb7b76de370b03f8ba59ea103097"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
+ "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
- "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-quic",
@@ -4174,51 +4555,39 @@ dependencies = [
  "libp2p-webrtc",
  "libp2p-websocket",
  "libp2p-yamux",
- "multiaddr 0.16.0",
- "parking_lot 0.12.1",
+ "multiaddr",
  "pin-project",
- "smallvec",
 ]
 
 [[package]]
-name = "libp2p-core"
-version = "0.38.0"
+name = "libp2p-allow-block-list"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
+checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
 dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "log",
- "multiaddr 0.16.0",
- "multihash 0.16.3",
- "multistream-select",
- "once_cell",
- "parking_lot 0.12.1",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "rw-stream-sink",
- "sec1",
- "sha2 0.10.6",
- "smallvec",
- "thiserror",
- "unsigned-varint",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "void",
- "zeroize",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "void",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.39.1"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7f8b7d65c070a5a1b5f8f0510648189da08f787b8963f8e21219e0710733af"
+checksum = "3c1df63c0b582aa434fb09b2d86897fa2b419ffeccf934b36f87fcedc8e835c2"
 dependencies = [
  "either",
  "fnv",
@@ -4227,7 +4596,7 @@ dependencies = [
  "instant",
  "libp2p-identity",
  "log",
- "multiaddr 0.17.0",
+ "multiaddr",
  "multihash 0.17.0",
  "multistream-select",
  "once_cell",
@@ -4244,12 +4613,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e42a271c1b49f789b92f7fc87749fa79ce5c7bdc88cbdfacb818a4bca47fec5"
+checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
 dependencies = [
  "futures",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
  "parking_lot 0.12.1",
  "smallvec",
@@ -4258,20 +4627,21 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.41.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c052d0026f4817b44869bfb6810f4e1112f43aec8553f2cb38881c524b563abf"
+checksum = "5455f472243e63b9c497ff320ded0314254a9eb751799a39c283c6f20b793f3c"
 dependencies = [
  "asynchronous-codec",
+ "either",
  "futures",
  "futures-timer",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
- "lru 0.8.1",
- "prost",
- "prost-build",
- "prost-codec",
+ "lru 0.10.0",
+ "quick-protobuf",
+ "quick-protobuf-codec",
  "smallvec",
  "thiserror",
  "void",
@@ -4279,29 +4649,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8ea433ae0cea7e3315354305237b9897afe45278b2118a7a57ca744e70fd27"
+checksum = "9e2d584751cecb2aabaa56106be6be91338a60a0f4e420cf2af639204f596fc1"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "log",
- "multiaddr 0.17.0",
+ "multiaddr",
  "multihash 0.17.0",
- "prost",
  "quick-protobuf",
  "rand 0.8.5",
+ "sha2 0.10.7",
  "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.42.1"
+version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
+checksum = "39d5ef876a2b2323d63c258e63c2f8e36f205fe5a11f0b3095d59635650790ff"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.4",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -4309,13 +4679,13 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
- "prost",
- "prost-build",
+ "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "smallvec",
  "thiserror",
  "uint",
@@ -4325,19 +4695,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.42.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f378264aade9872d6ccd315c0accc18be3a35d15fc1b9c36e5b6f983b62b5b"
+checksum = "19983e1f949f979a928f2c603de1cf180cc0dc23e4ac93a62651ccb18341460b"
 dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "trust-dns-proto",
  "void",
@@ -4345,11 +4716,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
+checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
 dependencies = [
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-ping",
@@ -4358,39 +4729,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-mplex"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03805b44107aa013e7cbbfa5627b31c36cbedfdfb00603c0311998882bc4bace"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "futures",
- "libp2p-core 0.38.0",
- "log",
- "nohash-hasher",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "smallvec",
- "unsigned-varint",
-]
-
-[[package]]
 name = "libp2p-noise"
-version = "0.41.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978cb57efe82e892ec6f348a536bfbd9fee677adbe5689d7a93ad3a9bffbf2e"
+checksum = "9c3673da89d29936bc6435bafc638e2f184180d554ce844db65915113f86ec5e"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "log",
  "once_cell",
- "prost",
- "prost-build",
+ "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "snow",
  "static_assertions",
  "thiserror",
@@ -4400,14 +4753,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "929fcace45a112536e22b3dcfd4db538723ef9c3cb79f672b98be2cc8e25f37f"
+checksum = "3e57759c19c28a73ef1eb3585ca410cefb72c1a709fcf6de1612a378e4219202"
 dependencies = [
+ "either",
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
@@ -4416,15 +4770,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha"
+version = "0.7.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e7c867e95c8130667b24409d236d37598270e6da69b3baf54213ba31ffca59"
+checksum = "c6b26abd81cd2398382a1edfe739b539775be8a90fa6914f39b2ab49571ec735"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
@@ -4437,49 +4792,46 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3236168796727bfcf4927f766393415361e2c644b08bedb6a6b13d957c9a4884"
+checksum = "7ffdb374267d42dc5ed5bc53f6e601d4a64ac5964779c6e40bb9e4f14c1e30d5"
 dependencies = [
  "async-trait",
- "bytes",
  "futures",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
- "log",
  "rand 0.8.5",
  "smallvec",
- "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.41.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
+checksum = "903b3d592d7694e56204d211f29d31bc004be99386644ba8731fc3e3ef27b296"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
- "pin-project",
  "rand 0.8.5",
  "smallvec",
- "thiserror",
  "tokio",
  "void",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d527d5827582abd44a6d80c07ff8b50b4ee238a8979e05998474179e79dc400"
+checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
 dependencies = [
  "heck",
  "quote",
@@ -4488,17 +4840,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257baf6df8f2df39678b86c578961d48cc8b68642a12f0f763f56c8e5858d"
+checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
 ]
 
@@ -4510,7 +4862,7 @@ checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.39.1",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen 0.10.0",
  "ring",
@@ -4523,13 +4875,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb1a35299860e0d4b3c02a3e74e3b293ad35ae0cee8a056363b0c862d082069"
+checksum = "77dff9d32353a5887adb86c8afc1de1a94d9e8c3bc6df8b2201d7cdf5c848f43"
 dependencies = [
  "futures",
  "js-sys",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4537,9 +4889,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc"
-version = "0.4.0-alpha"
+version = "0.4.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb6cd86dd68cba72308ea05de1cebf3ba0ae6e187c40548167955d4e3970f6a"
+checksum = "dba48592edbc2f60b4bc7c10d65445b0c3964c07df26fdf493b6880d33be36f8"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4548,13 +4900,13 @@ dependencies = [
  "futures-timer",
  "hex",
  "if-watch",
- "libp2p-core 0.38.0",
+ "libp2p-core",
+ "libp2p-identity",
  "libp2p-noise",
  "log",
- "multihash 0.16.3",
- "prost",
- "prost-build",
- "prost-codec",
+ "multihash 0.17.0",
+ "quick-protobuf",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "rcgen 0.9.3",
  "serde",
@@ -4568,14 +4920,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d705506030d5c0aaf2882437c70dab437605f21c5f9811978f694e6917a3b54"
+checksum = "111273f7b3d3510524c752e8b7a5314b7f7a1fee7e68161c01a7d72cbb06db9f"
 dependencies = [
  "either",
  "futures",
  "futures-rustls",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
  "parking_lot 0.12.1",
  "quicksink",
@@ -4587,23 +4939,22 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.42.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f63594a0aa818642d9d4915c791945053877253f08a3626f13416b5cd928a29"
+checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
 dependencies = [
  "futures",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
- "parking_lot 0.12.1",
  "thiserror",
  "yamux",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.3+7.4.4"
+version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4664,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4708,21 +5059,21 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
+name = "linux-raw-sys"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -4730,12 +5081,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lru"
@@ -4751,6 +5099,15 @@ name = "lru"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
  "hashbrown 0.13.2",
 ]
@@ -4794,6 +5151,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_magic"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614b1304ab7877b499925b4dcc5223ff480f2646ad4db1ee7065badb8d530439"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d72c1b662d07b8e482c80d3a7fc4168e058b3bef4c573e94feb714b670f406"
+dependencies = [
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d7d9e6e234c040dafc745c7592738d56a03ad04b1fa04ab60821deb597466a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd19f13cfd2bfbd83692adfef8c244fe5109b3eb822a1fb4e0a6253b406cd81"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4816,10 +5226,11 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
@@ -4829,7 +5240,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4840,11 +5251,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.36.11",
+ "rustix 0.37.20",
 ]
 
 [[package]]
@@ -4875,6 +5286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memory-db"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4882,12 +5302,6 @@ checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
 ]
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "merlin"
@@ -4928,21 +5342,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.6"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "futures",
  "log",
@@ -4961,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -4976,9 +5398,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -4991,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -5003,31 +5425,14 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
+checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "multibase",
- "multihash 0.16.3",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
-name = "multiaddr"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b53e0cc5907a5c216ba6584bf74be8ab47d6d6289f72793b2dddbf15dc3bf8c"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
+ "log",
  "multibase",
  "multihash 0.17.0",
  "percent-encoding",
@@ -5058,9 +5463,9 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "core2",
- "digest 0.10.6",
+ "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "unsigned-varint",
 ]
@@ -5072,9 +5477,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "core2",
- "digest 0.10.6",
+ "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "unsigned-varint",
 ]
 
@@ -5173,7 +5578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "libc",
  "netlink-packet-core",
@@ -5226,7 +5631,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -5280,7 +5685,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.4",
  "itoa",
 ]
 
@@ -5326,23 +5731,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.29.0"
+name = "number_prefix"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "crc32fast",
- "hashbrown 0.12.3",
- "indexmap",
- "memchr",
-]
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.13.2",
+ "indexmap",
  "memchr",
 ]
 
@@ -5366,9 +5768,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -5390,9 +5792,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "orchestra"
-version = "0.2.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0766f60d83cac01c6e3f3bc36aaa9056e48bea0deddb98a8c74de6021f3061"
+checksum = "227585216d05ba65c7ab0a0450a3cf2cbd81a98862a54c4df8e14d5ac6adb015"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -5407,12 +5809,11 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.2.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8e83dbd049009426b445424a1104c78e6172a4c13e3614e52a38262785a5d7"
+checksum = "2871aadd82a2c216ee68a69837a526dfe788ecbe74c4c5038a6acdbff6653066"
 dependencies = [
- "expander 1.0.0",
- "indexmap",
+ "expander 0.0.6",
  "itertools",
  "petgraph",
  "proc-macro-crate",
@@ -5436,9 +5837,9 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2 0.10.6",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -5447,9 +5848,9 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2 0.10.6",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -5459,13 +5860,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
- "libm 0.1.4",
+ "libm",
 ]
 
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5481,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5497,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5511,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5524,7 +5925,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto",
  "sp-consensus-babe",
- "sp-consensus-vrf",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-session",
@@ -5535,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5555,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5570,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5589,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -5613,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5629,9 +6030,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-bridge-aleph"
+version = "0.1.0"
+dependencies = [
+ "bp-aleph-header-chain",
+ "bp-header-chain",
+ "bp-runtime",
+ "bp-test-utils",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+]
+
+[[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5650,7 +6072,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5669,7 +6091,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5686,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5703,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5721,7 +6143,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5744,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5757,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5775,8 +6197,9 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
+ "docify",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
@@ -5793,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5816,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5832,7 +6255,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5852,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5869,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5884,9 +6307,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-message-queue"
+version = "7.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5903,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5919,7 +6361,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5935,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5952,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5972,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -5983,7 +6425,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6000,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6024,7 +6466,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6041,7 +6483,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6056,7 +6498,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6074,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6089,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6108,7 +6550,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6125,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6146,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6162,13 +6604,18 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex-literal 0.3.4",
+ "log",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
+ "sp-arithmetic",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -6176,7 +6623,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6199,18 +6646,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6219,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6228,7 +6675,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6245,8 +6692,9 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -6259,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6277,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6296,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6312,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6328,7 +6776,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6340,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6357,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6373,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6388,7 +6836,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6402,8 +6850,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -6423,8 +6871,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6443,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.40#a4c24e150d526638f14cb487ae09847f287bcba7"
+source = "git+https://github.com/paritytech/cumulus.git?branch=master#486d6e04eaf08e466e239f072539b6a801c032f7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -6454,9 +6902,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bfb81cf5c90a222db2fb7b3a7cbf8cc7f38dfb6647aca4d98edf8281f56ed5"
+checksum = "4890dcb9556136a4ec2b0c51fa4a08c8b733b829506af8fff2e853f3a065985b"
 dependencies = [
  "blake2",
  "crc32fast",
@@ -6474,11 +6922,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
+checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.4",
  "bitvec",
  "byte-slice-cast",
  "bytes",
@@ -6489,9 +6937,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6506,6 +6954,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
+name = "parity-util-mem"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
+dependencies = [
+ "cfg-if",
+ "ethereum-types",
+ "hashbrown 0.12.3",
+ "impl-trait-for-tuples",
+ "lru 0.8.1",
+ "parity-util-mem-derive",
+ "parking_lot 0.12.1",
+ "primitive-types",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parity-util-mem-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6513,9 +6990,9 @@ checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -6535,7 +7012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -6547,23 +7024,29 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
+
+[[package]]
+name = "partial_sort"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7924d1d0ad836f665c9065e26d016c673ece3993f30d340068b16f282afc1156"
 
 [[package]]
 name = "paste"
@@ -6586,7 +7069,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6615,15 +7098,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.5.6"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -6631,9 +7114,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.6"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6641,26 +7124,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.6"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.6"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -6675,22 +7158,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -6717,21 +7200,25 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.6",
+ "spki 0.7.2",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
-
-[[package]]
-name = "platforms"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platforms"
@@ -6741,14 +7228,17 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
+ "futures-timer",
+ "polkadot-node-jaeger",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.5",
  "tracing-gum",
@@ -6756,10 +7246,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
+ "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6770,8 +7261,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "derive_more",
  "fatality",
@@ -6793,8 +7284,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "fatality",
  "futures",
@@ -6814,15 +7305,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
  "futures",
  "log",
  "polkadot-client",
- "polkadot-node-core-pvf",
+ "polkadot-node-core-pvf-execute-worker",
+ "polkadot-node-core-pvf-prepare-worker",
  "polkadot-node-metrics",
  "polkadot-performance-test",
  "polkadot-service",
@@ -6835,6 +7327,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-keyring",
+ "sp-maybe-compressed-blob",
  "substrate-build-script-utils",
  "thiserror",
  "try-runtime-cli",
@@ -6842,8 +7335,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-client"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -6884,8 +7377,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -6906,8 +7399,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6918,8 +7411,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "derive_more",
  "fatality",
@@ -6943,8 +7436,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6957,8 +7450,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6977,8 +7470,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7000,8 +7493,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7018,8 +7511,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7047,8 +7540,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "futures",
@@ -7068,8 +7561,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7087,8 +7580,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7102,8 +7595,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "async-trait",
  "futures",
@@ -7122,8 +7615,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7137,8 +7630,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7154,8 +7647,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "fatality",
  "futures",
@@ -7173,8 +7666,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "async-trait",
  "futures",
@@ -7190,8 +7683,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7208,44 +7701,39 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "always-assert",
- "assert_matches",
- "cpu-time",
  "futures",
  "futures-timer",
  "libc",
  "parity-scale-codec",
  "pin-project",
  "polkadot-core-primitives",
+ "polkadot-node-core-pvf-common",
+ "polkadot-node-core-pvf-execute-worker",
+ "polkadot-node-core-pvf-prepare-worker",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-parachain",
  "polkadot-primitives",
  "rand 0.8.5",
- "rayon",
- "sc-executor",
- "sc-executor-common",
- "sc-executor-wasmtime",
  "slotmap",
  "sp-core",
- "sp-externalities",
- "sp-io",
  "sp-maybe-compressed-blob",
  "sp-tracing",
  "sp-wasm-interface",
+ "substrate-build-script-utils",
  "tempfile",
- "tikv-jemalloc-ctl",
  "tokio",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -7259,9 +7747,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-node-core-pvf-common"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
+dependencies = [
+ "cpu-time",
+ "futures",
+ "libc",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "sc-executor",
+ "sc-executor-common",
+ "sc-executor-wasmtime",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-tracing",
+ "substrate-build-script-utils",
+ "tokio",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-pvf-execute-worker"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
+dependencies = [
+ "cpu-time",
+ "futures",
+ "parity-scale-codec",
+ "polkadot-node-core-pvf-common",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "rayon",
+ "sp-core",
+ "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-pvf-prepare-worker"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
+dependencies = [
+ "futures",
+ "libc",
+ "parity-scale-codec",
+ "polkadot-node-core-pvf-common",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "rayon",
+ "sc-executor",
+ "sc-executor-common",
+ "sc-executor-wasmtime",
+ "sp-io",
+ "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing-gum",
+]
+
+[[package]]
 name = "polkadot-node-core-runtime-api"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "futures",
  "lru 0.9.0",
@@ -7275,8 +7829,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "lazy_static",
  "log",
@@ -7293,8 +7847,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bs58",
  "futures",
@@ -7312,9 +7866,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
+ "async-channel",
  "async-trait",
  "derive_more",
  "fatality",
@@ -7334,8 +7889,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -7346,19 +7901,18 @@ dependencies = [
  "serde",
  "sp-application-crypto",
  "sp-consensus-babe",
- "sp-consensus-vrf",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
  "sp-runtime",
  "thiserror",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7367,8 +7921,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7390,8 +7944,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7423,8 +7977,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "async-trait",
  "futures",
@@ -7446,8 +8000,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -7463,27 +8017,29 @@ dependencies = [
 
 [[package]]
 name = "polkadot-performance-test"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "env_logger 0.9.3",
  "kusama-runtime",
  "log",
  "polkadot-erasure-coding",
- "polkadot-node-core-pvf",
+ "polkadot-node-core-pvf-prepare-worker",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "quote",
+ "sc-executor-common",
+ "sp-maybe-compressed-blob",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
- "hex-literal",
+ "hex-literal 0.4.1",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -7505,8 +8061,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -7537,8 +8093,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7549,7 +8105,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.4.1",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -7559,6 +8115,7 @@ dependencies = [
  "pallet-bounties",
  "pallet-child-bounties",
  "pallet-collective",
+ "pallet-conviction-voting",
  "pallet-democracy",
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
@@ -7569,6 +8126,7 @@ dependencies = [
  "pallet-im-online",
  "pallet-indices",
  "pallet-membership",
+ "pallet-message-queue",
  "pallet-multisig",
  "pallet-nomination-pools",
  "pallet-nomination-pools-benchmarking",
@@ -7577,6 +8135,7 @@ dependencies = [
  "pallet-offences-benchmarking",
  "pallet-preimage",
  "pallet-proxy",
+ "pallet-referenda",
  "pallet-scheduler",
  "pallet-session",
  "pallet-session-benchmarking",
@@ -7590,6 +8149,7 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
+ "pallet-whitelist",
  "pallet-xcm",
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7602,6 +8162,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "sp-api",
+ "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
@@ -7627,8 +8188,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7673,8 +8234,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-constants"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -7687,8 +8248,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -7699,10 +8260,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bitvec",
  "derive_more",
  "frame-benchmarking",
@@ -7713,6 +8274,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-balances",
+ "pallet-message-queue",
  "pallet-session",
  "pallet-staking",
  "pallet-timestamp",
@@ -7743,15 +8305,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "async-trait",
  "frame-benchmarking-cli",
  "frame-support",
  "frame-system-rpc-runtime-api",
  "futures",
- "hex-literal",
+ "hex-literal 0.4.1",
  "kusama-runtime",
  "kvdb",
  "kvdb-rocksdb",
@@ -7852,12 +8414,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
  "futures",
+ "futures-timer",
  "indexmap",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
@@ -7873,8 +8436,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7883,18 +8446,18 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
  "log",
  "pin-project-lite 0.2.9",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7922,15 +8485,21 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug 0.3.0",
- "universal-hash 0.5.0",
+ "universal-hash 0.5.1",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "ppv-lite86"
@@ -7979,6 +8548,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7986,6 +8565,7 @@ checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -7993,11 +8573,10 @@ dependencies = [
 
 [[package]]
 name = "prioritized-metered-channel"
-version = "0.4.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3caef72a78ca8e77cbdfa87dd516ebb79d4cbe5b42e3b8435b463a8261339ff"
+checksum = "382698e48a268c832d0b181ed438374a6bb708a82a8ca273bb0f61c74cf209c4"
 dependencies = [
- "async-channel",
  "coarsetime",
  "crossbeam-queue",
  "derive_more",
@@ -8043,10 +8622,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.53"
+name = "proc-macro-warning"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "70550716265d1ec349c41f70dd4f964b4fd88394efe4405f0c1da679c4799a07"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -8067,21 +8657,21 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
+checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
 dependencies = [
  "dtoa",
  "itoa",
  "parking_lot 0.12.1",
- "prometheus-client-derive-text-encode",
+ "prometheus-client-derive-encode",
 ]
 
 [[package]]
-name = "prometheus-client-derive-text-encode"
-version = "0.3.0"
+name = "prometheus-client-derive-encode"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
+checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8090,9 +8680,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -8100,9 +8690,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -8111,7 +8701,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost",
  "prost-types",
  "regex",
@@ -8121,23 +8711,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-codec"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "prost",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -8148,9 +8725,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
@@ -8180,6 +8757,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-protobuf-codec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1693116345026436eb2f10b677806169c1a1260c1c60eaaffe3fb5a29ae23d8b"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "quicksink"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8192,9 +8782,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
+checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -8210,9 +8800,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -8282,7 +8872,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -8339,7 +8929,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.22",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -8352,7 +8942,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.22",
  "yasna",
 ]
 
@@ -8362,7 +8952,16 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -8371,8 +8970,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
- "redox_syscall",
+ "getrandom 0.2.10",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -8406,14 +9005,14 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "regalloc2"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
+checksum = "80535183cae11b149d618fbd3c37e38d7cda589d82d7769e196ca9a9042d7621"
 dependencies = [
  "fxhash",
  "log",
@@ -8423,13 +9022,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.2",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -8438,7 +9037,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -8448,16 +9047,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "region"
-version = "3.0.0"
+name = "regex-syntax"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
-dependencies = [
- "bitflags",
- "libc",
- "mach",
- "winapi",
-]
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "resolv-conf"
@@ -8475,9 +9068,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac 0.12.1",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -8496,10 +9099,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.19.0"
+name = "rlp"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -8507,8 +9120,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -8518,7 +9131,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.4.1",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -8536,6 +9149,7 @@ dependencies = [
  "pallet-im-online",
  "pallet-indices",
  "pallet-membership",
+ "pallet-message-queue",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nis",
@@ -8593,8 +9207,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8668,9 +9282,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -8704,30 +9318,30 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
+version = "0.36.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
- "io-lifetimes 0.7.5",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.0.46",
- "windows-sys 0.42.0",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
- "io-lifetimes 1.0.9",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8756,10 +9370,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.6.2"
+name = "rustls"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct 0.7.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -8773,7 +9399,17 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -8801,9 +9437,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safe_arch"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+checksum = "62a7484307bd40f8f7ccbacccac730108f2cae119a3b11c74485b48aa9ea650f"
 dependencies = [
  "bytemuck",
 ]
@@ -8820,7 +9456,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "log",
  "sp-core",
@@ -8831,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures",
@@ -8839,6 +9475,7 @@ dependencies = [
  "ip_network",
  "libp2p",
  "log",
+ "multihash 0.17.0",
  "parity-scale-codec",
  "prost",
  "prost-build",
@@ -8859,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8882,7 +9519,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8897,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -8916,25 +9553,25 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
  "clap",
  "fdlimit",
  "futures",
- "libp2p",
+ "libp2p-identity",
  "log",
  "names",
  "parity-scale-codec",
@@ -8967,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "fnv",
  "futures",
@@ -8986,6 +9623,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
+ "sp-statement-store",
  "sp-storage",
  "substrate-prometheus-endpoint",
 ]
@@ -8993,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9019,12 +9657,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p",
+ "libp2p-identity",
  "log",
  "mockall",
  "parking_lot 0.12.1",
@@ -9044,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures",
@@ -9073,13 +9711,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "fork-tree",
  "futures",
  "log",
- "merlin",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -9092,7 +9729,6 @@ dependencies = [
  "sc-keystore",
  "sc-telemetry",
  "scale-info",
- "schnorrkel",
  "sp-api",
  "sp-application-crypto",
  "sp-block-builder",
@@ -9100,7 +9736,6 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-slots",
- "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
  "sp-keystore",
@@ -9112,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9134,9 +9769,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
+ "async-channel",
  "async-trait",
  "fnv",
  "futures",
@@ -9169,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9188,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9201,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "ahash 0.8.3",
  "array-bytes 4.2.0",
@@ -9241,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -9261,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures",
@@ -9284,13 +9920,12 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
- "lru 0.8.1",
+ "lru 0.10.0",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-executor-common",
- "sc-executor-wasmi",
  "sc-executor-wasmtime",
  "sp-api",
  "sp-core",
@@ -9302,46 +9937,31 @@ dependencies = [
  "sp-version",
  "sp-wasm-interface",
  "tracing",
- "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
- "wasmi",
-]
-
-[[package]]
-name = "sc-executor-wasmi"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
-dependencies = [
- "log",
- "sc-allocator",
- "sc-executor-common",
- "sp-runtime-interface",
- "sp-wasm-interface",
- "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
  "log",
  "once_cell",
- "rustix 0.36.11",
+ "rustix 0.36.14",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -9352,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "ansi_term",
  "futures",
@@ -9368,10 +9988,9 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
- "async-trait",
  "parking_lot 0.12.1",
  "serde_json",
  "sp-application-crypto",
@@ -9383,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -9398,21 +10017,22 @@ dependencies = [
  "libp2p",
  "linked_hash_set",
  "log",
- "lru 0.8.1",
+ "lru 0.10.0",
  "mockall",
  "parity-scale-codec",
  "parking_lot 0.12.1",
+ "partial_sort",
  "pin-project",
  "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sc-network-common",
- "sc-peerset",
  "sc-utils",
  "serde",
  "serde_json",
  "smallvec",
+ "snow",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -9421,17 +10041,19 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "thiserror",
  "unsigned-varint",
+ "wasm-timer",
  "zeroize",
 ]
 
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
+ "async-channel",
  "cid",
  "futures",
- "libp2p",
+ "libp2p-identity",
  "log",
  "prost",
  "prost-build",
@@ -9447,19 +10069,18 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures",
  "futures-timer",
- "libp2p",
+ "libp2p-identity",
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
- "sc-peerset",
  "sc-utils",
  "serde",
  "smallvec",
@@ -9475,17 +10096,16 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "ahash 0.8.3",
  "futures",
  "futures-timer",
  "libp2p",
  "log",
- "lru 0.8.1",
+ "lru 0.10.0",
  "sc-network",
  "sc-network-common",
- "sc-peerset",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -9494,11 +10114,12 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
+ "async-channel",
  "futures",
- "libp2p",
+ "libp2p-identity",
  "log",
  "parity-scale-codec",
  "prost",
@@ -9506,7 +10127,6 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-common",
- "sc-peerset",
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
@@ -9516,16 +10136,17 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
+ "async-channel",
  "async-trait",
  "fork-tree",
  "futures",
  "futures-timer",
  "libp2p",
  "log",
- "lru 0.8.1",
+ "lru 0.10.0",
  "mockall",
  "parity-scale-codec",
  "prost",
@@ -9534,7 +10155,6 @@ dependencies = [
  "sc-consensus",
  "sc-network",
  "sc-network-common",
- "sc-peerset",
  "sc-utils",
  "smallvec",
  "sp-arithmetic",
@@ -9550,17 +10170,15 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
  "libp2p",
  "log",
  "parity-scale-codec",
- "pin-project",
  "sc-network",
  "sc-network-common",
- "sc-peerset",
  "sc-utils",
  "sp-consensus",
  "sp-runtime",
@@ -9570,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -9578,7 +10196,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "libp2p",
  "num_cpus",
  "once_cell",
@@ -9588,7 +10206,6 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-common",
- "sc-peerset",
  "sc-utils",
  "sp-api",
  "sp-core",
@@ -9599,22 +10216,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-peerset"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
-dependencies = [
- "futures",
- "libp2p",
- "log",
- "sc-utils",
- "serde_json",
- "wasm-timer",
-]
-
-[[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9623,7 +10227,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9646,6 +10250,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-session",
+ "sp-statement-store",
  "sp-version",
  "tokio",
 ]
@@ -9653,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9672,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -9687,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -9713,7 +10318,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "directories",
@@ -9779,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9790,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "clap",
  "fs4",
@@ -9806,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9825,7 +10430,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "futures",
  "libc",
@@ -9844,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "chrono",
  "futures",
@@ -9863,7 +10468,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9894,25 +10499,24 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "linked-hash-map",
  "log",
- "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-client-api",
@@ -9932,13 +10536,15 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures",
  "log",
+ "parity-scale-codec",
  "serde",
  "sp-blockchain",
+ "sp-core",
  "sp-runtime",
  "thiserror",
 ]
@@ -9946,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-channel",
  "futures",
@@ -9960,9 +10566,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.5.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
+checksum = "ad560913365790f17cbf12479491169f01b9d46d29cfc7422bf8c64bdc61b731"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9974,9 +10580,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.5.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
+checksum = "19df9bd9ace6cc2fe19387c96ce677e823e07d017ceed253e7bb3d1d1bd9c73b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10072,10 +10678,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
- "generic-array 0.14.6",
- "pkcs8",
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.6",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -10109,11 +10729,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -10122,9 +10742,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -10156,32 +10776,41 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
  "serde",
 ]
 
@@ -10206,7 +10835,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -10236,22 +10865,22 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -10285,15 +10914,25 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "simba"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50582927ed6f77e4ac020c057f37a268fc6aebc29225050365aacbb9deeeddc4"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex",
@@ -10319,14 +10958,14 @@ dependencies = [
 
 [[package]]
 name = "slice-group-by"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -10369,7 +11008,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "subtle",
 ]
 
@@ -10381,6 +11020,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10403,13 +11052,15 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "sp-api-proc-macro",
  "sp-core",
+ "sp-metadata-ir",
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
@@ -10421,21 +11072,21 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "Inflector",
  "blake2",
- "expander 1.0.0",
+ "expander 2.0.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "sp-application-crypto"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10447,8 +11098,8 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "16.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10462,7 +11113,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10475,7 +11126,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10487,11 +11138,11 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "futures",
  "log",
- "lru 0.8.1",
+ "lru 0.10.0",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sp-api",
@@ -10505,7 +11156,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures",
@@ -10520,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10538,10 +11189,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
- "merlin",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -10549,7 +11199,6 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
  "sp-keystore",
@@ -10561,7 +11210,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -10580,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10598,7 +11247,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10608,28 +11257,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-vrf"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "schnorrkel",
- "sp-core",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "sp-core"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "21.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "array-bytes 4.2.0",
- "base58",
- "bitflags",
+ "bitflags 1.3.2",
  "blake2",
  "bounded-collections",
+ "bs58",
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
@@ -10642,6 +11278,7 @@ dependencies = [
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
+ "paste",
  "primitive-types",
  "rand 0.8.5",
  "regex",
@@ -10665,13 +11302,13 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "digest 0.10.6",
- "sha2 0.10.6",
+ "digest 0.10.7",
+ "sha2 0.10.7",
  "sha3",
  "sp-std",
  "twox-hash",
@@ -10679,19 +11316,19 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing-proc-macro"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "9.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10699,18 +11336,18 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "8.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "sp-externalities"
-version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10721,7 +11358,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10735,8 +11372,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "bytes",
  "ed25519",
@@ -10745,6 +11382,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "rustversion",
  "secp256k1",
  "sp-core",
  "sp-externalities",
@@ -10760,8 +11398,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "24.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10771,15 +11409,12 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "0.27.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
- "async-trait",
  "futures",
- "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "schnorrkel",
  "serde",
  "sp-core",
  "sp-externalities",
@@ -10789,16 +11424,27 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "thiserror",
- "zstd",
+ "zstd 0.12.3+zstd.1.5.2",
+]
+
+[[package]]
+name = "sp-metadata-ir"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
+dependencies = [
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -10816,7 +11462,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10830,7 +11476,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10839,8 +11485,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "8.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10850,7 +11496,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10859,8 +11505,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "24.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10881,8 +11527,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10899,20 +11545,20 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10926,10 +11572,11 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -10937,8 +11584,8 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "0.28.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "hash-db",
  "log",
@@ -10956,14 +11603,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-statement-store"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
+ "thiserror",
+]
+
+[[package]]
 name = "sp-std"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "8.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 
 [[package]]
 name = "sp-storage"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10976,7 +11641,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -10990,8 +11655,8 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11003,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11012,7 +11677,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "log",
@@ -11027,12 +11692,12 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "lazy_static",
  "memory-db",
  "nohash-hasher",
@@ -11050,8 +11715,8 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11067,33 +11732,32 @@ dependencies = [
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "8.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "sp-std",
- "wasmi",
  "wasmtime",
 ]
 
 [[package]]
 name = "sp-weights"
-version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11112,20 +11776,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spinners"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08615eea740067d9899969bc2891c68a19c315cb1f66640af9a9ecb91b13bcab"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "strum",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.6",
 ]
 
 [[package]]
 name = "ss58-registry"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf0bd63593ef78eca595a7fc25e9a443ca46fe69fd472f8f09f5245cdcd769d"
+checksum = "eb47a8ad42e5fc72d5b1eb104a5546937eaf39843499948bb666d6e93c62423b"
 dependencies = [
  "Inflector",
  "num-format",
@@ -11166,7 +11851,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg_aliases",
  "libc",
  "parking_lot 0.11.2",
@@ -11264,15 +11949,15 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
- "platforms 2.0.0",
+ "platforms",
 ]
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11291,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "hyper",
  "log",
@@ -11303,7 +11988,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11316,7 +12001,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -11335,16 +12020,17 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "ansi_term",
  "build-helper",
  "cargo_metadata",
  "filetime",
+ "parity-wasm",
  "sp-maybe-compressed-blob",
  "strum",
  "tempfile",
- "toml",
+ "toml 0.7.4",
  "walkdir",
  "wasm-opt",
 ]
@@ -11377,9 +12063,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11400,11 +12086,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75182f12f490e953596550b65ee31bda7c8e043d9386174b353bda50838c3fd"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -11427,21 +12113,22 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix 0.36.11",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11476,7 +12163,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -11551,9 +12238,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",
@@ -11563,15 +12250,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -11588,11 +12275,20 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -11622,33 +12318,43 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.9",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -11663,10 +12369,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.12"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.2",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.9",
@@ -11676,9 +12392,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -11699,18 +12415,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.1"
+name = "toml"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.7"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -11728,11 +12461,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -11771,20 +12504,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -11802,8 +12535,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -11813,14 +12546,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum-proc-macro"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
- "expander 0.0.6",
+ "expander 2.0.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -11907,7 +12640,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -11944,7 +12677,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
+source = "git+https://github.com/paritytech/substrate?branch=master#074dc1dfee4132b597db6eb147a86c72b751f03c"
 dependencies = [
  "async-trait",
  "clap",
@@ -11975,7 +12708,7 @@ dependencies = [
  "sp-version",
  "sp-weights",
  "substrate-rpc-client",
- "zstd",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]
@@ -12010,7 +12743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -12047,9 +12780,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -12078,15 +12811,15 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -12112,12 +12845,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
+ "idna 0.4.0",
  "percent-encoding",
 ]
 
@@ -12129,11 +12862,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -12187,11 +12920,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -12215,9 +12947,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -12225,24 +12957,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -12252,9 +12984,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12262,22 +12994,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-instrument"
@@ -12290,9 +13022,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a303793cbc01fb96551badfc7367db6007396bba6bac97936b3c8b6f7fdb41"
+checksum = "87fef6d0d508f08334e0ab0e6877feb4c0ecb3956bcf2cb950699b22fedf3e9c"
 dependencies = [
  "anyhow",
  "libc",
@@ -12306,9 +13038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c9deb56f8a9f2ec177b3bd642a8205621835944ed5da55f2388ef216aca5a4"
+checksum = "bc816bbc1596c8f2e8127e137a760c798023ef3d378f2ae51f0f1840e2dfa445"
 dependencies = [
  "anyhow",
  "cxx",
@@ -12318,15 +13050,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4432e28b542738a9776cedf92e8a99d8991c7b4667ee2c7ccddfb479dd2856a7"
+checksum = "40199e4f68ef1071b3c6d0bd8026a12b481865d4b9e49c156932ea9a6234dd14"
 dependencies = [
  "anyhow",
  "cc",
  "cxx",
  "cxx-build",
- "regex",
 ]
 
 [[package]]
@@ -12345,44 +13076,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmi"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c326c93fbf86419608361a2c925a31754cf109da1b8b55737070b4d6669422"
-dependencies = [
- "parity-wasm",
- "wasmi-validation",
- "wasmi_core",
-]
-
-[[package]]
-name = "wasmi-validation"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
-dependencies = [
- "parity-wasm",
-]
-
-[[package]]
-name = "wasmi_core"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d20cb3c59b788653d99541c646c561c9dd26506f25c0cebfe810659c54c6d7"
-dependencies = [
- "downcast-rs",
- "libm 0.2.6",
- "memory_units",
- "num-rational",
- "num-traits",
- "region",
-]
-
-[[package]]
 name = "wasmparser"
-version = "0.100.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
+checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
 dependencies = [
  "indexmap",
  "url",
@@ -12390,9 +13087,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e89f9819523447330ffd70367ef4a18d8c832e24e8150fe054d1d912841632"
+checksum = "f907fdead3153cb9bfb7a93bbd5b62629472dc06dee83605358c64c52ed3dda9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -12400,7 +13097,7 @@ dependencies = [
  "indexmap",
  "libc",
  "log",
- "object 0.29.0",
+ "object",
  "once_cell",
  "paste",
  "psm",
@@ -12413,43 +13110,43 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd3a5e46c198032da934469f3a6e48649d1f9142438e4fd4617b68a35644b8a"
+checksum = "d3b9daa7c14cd4fa3edbf69de994408d5f4b7b0959ac13fa69d465f6597f810d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b389ae9b678b9c3851091a4804f4182d688d27aff7abc9aa37fa7be37d8ecffa"
+checksum = "c86437fa68626fe896e5afc69234bb2b5894949083586535f200385adfd71213"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.2",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.36.11",
+ "rustix 0.36.14",
  "serde",
- "sha2 0.10.6",
- "toml",
- "windows-sys 0.42.0",
- "zstd",
+ "sha2 0.10.7",
+ "toml 0.5.11",
+ "windows-sys 0.45.0",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b2c92a08c0db6efffd88fdc97d7aa9c7c63b03edb0971dbca745469f820e8c"
+checksum = "b1cefde0cce8cb700b1b21b6298a3837dba46521affd7b8c38a9ee2c869eee04"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -12457,27 +13154,43 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli 0.26.2",
+ "gimli",
  "log",
- "object 0.29.0",
+ "object",
  "target-lexicon",
  "thiserror",
  "wasmparser",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-cranelift-shared"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd041e382ef5aea1b9fc78442394f1a4f6d676ce457e7076ca4cb3f397882f8b"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-native",
+ "gimli",
+ "object",
+ "target-lexicon",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6db9fc52985ba06ca601f2ff0ff1f526c5d724c7ac267b47326304b0c97883"
+checksum = "a990198cee4197423045235bf89d3359e69bd2ea031005f4c2d901125955c949"
 dependencies = [
  "anyhow",
  "cranelift-entity",
- "gimli 0.26.2",
+ "gimli",
  "indexmap",
  "log",
- "object 0.29.0",
+ "object",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -12487,18 +13200,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77e3a52cd84d0f7f18554afa8060cfe564ccac61e3b0802d3fd4084772fa5f6"
+checksum = "0de48df552cfca1c9b750002d3e07b45772dd033b0b206d5c0968496abf31244"
 dependencies = [
- "addr2line 0.17.0",
+ "addr2line",
  "anyhow",
  "bincode",
  "cfg-if",
  "cpp_demangle",
- "gimli 0.26.2",
+ "gimli",
  "log",
- "object 0.29.0",
+ "object",
  "rustc-demangle",
  "serde",
  "target-lexicon",
@@ -12506,36 +13219,36 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0245e8a9347017c7185a72e215218a802ff561545c242953c11ba00fccc930f"
+checksum = "6e0554b84c15a27d76281d06838aed94e13a77d7bf604bbbaf548aa20eb93846"
 dependencies = [
- "object 0.29.0",
+ "object",
  "once_cell",
- "rustix 0.36.11",
+ "rustix 0.36.14",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d412e9340ab1c83867051d8d1d7c90aa8c9afc91da086088068e2734e25064"
+checksum = "aecae978b13f7f67efb23bd827373ace4578f2137ec110bbf6a4a7cde4121bbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d594e791b5fdd4dbaf8cf7ae62f2e4ff85018ce90f483ca6f42947688e48827d"
+checksum = "658cf6f325232b6760e202e5255d823da5e348fdea827eff0a2a22319000b441"
 dependencies = [
  "anyhow",
  "cc",
@@ -12545,21 +13258,21 @@ dependencies = [
  "log",
  "mach",
  "memfd",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "paste",
  "rand 0.8.5",
- "rustix 0.36.11",
+ "rustix 0.36.14",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "6.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6688d6f96d4dbc1f89fab626c56c1778936d122b5f4ae7a57c2eb42b8d982e2"
+checksum = "a4f6fffd2a1011887d57f07654dd112791e872e3ff4a2e626aee8059ee17f06f"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -12569,9 +13282,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12629,10 +13342,10 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "stun",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.22",
  "tokio",
  "turn",
  "url",
@@ -12669,7 +13382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942be5bd85f072c3128396f6e5a9bfb93ca8c1939ded735d177b7bcba9a13d05"
 dependencies = [
  "aes 0.6.0",
- "aes-gcm 0.10.1",
+ "aes-gcm 0.10.2",
  "async-trait",
  "bincode",
  "block-modes",
@@ -12677,7 +13390,7 @@ dependencies = [
  "ccm",
  "curve25519-dalek 3.2.0",
  "der-parser 8.2.0",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "hkdf",
  "hmac 0.12.1",
  "log",
@@ -12689,11 +13402,11 @@ dependencies = [
  "rcgen 0.9.3",
  "ring",
  "rustls 0.19.1",
- "sec1",
+ "sec1 0.3.0",
  "serde",
  "sha1",
- "sha2 0.10.6",
- "signature",
+ "sha2 0.10.7",
+ "signature 1.6.4",
  "subtle",
  "thiserror",
  "tokio",
@@ -12734,7 +13447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
 dependencies = [
  "log",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tokio",
  "webrtc-util",
@@ -12742,18 +13455,15 @@ dependencies = [
 
 [[package]]
 name = "webrtc-media"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a3c157a040324e5049bcbd644ffc9079e6738fa2cfab2bcff64e5cc4c00d7"
+checksum = "f72e1650a8ae006017d1a5280efb49e2610c19ccc3c0905b03b648aee9554991"
 dependencies = [
  "byteorder",
  "bytes",
- "derive_builder",
- "displaydoc",
  "rand 0.8.5",
  "rtp",
  "thiserror",
- "webrtc-util",
 ]
 
 [[package]]
@@ -12804,7 +13514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f1db1727772c05cf7a2cfece52c3aca8045ca1e176cd517d323489aa3c6d87"
 dependencies = [
  "async-trait",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "cc",
  "ipnet",
@@ -12820,8 +13530,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12832,7 +13542,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.4.1",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -12850,6 +13560,7 @@ dependencies = [
  "pallet-im-online",
  "pallet-indices",
  "pallet-membership",
+ "pallet-message-queue",
  "pallet-multisig",
  "pallet-nomination-pools",
  "pallet-nomination-pools-benchmarking",
@@ -12912,8 +13623,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12937,9 +13648,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b689b6c49d6549434bf944e6b0f39238cf63693cb7a147e9d887507fffa3b223"
+checksum = "40018623e2dba2602a9790faba8d33f2ebdebf4b86561b83928db735f8784728"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -12947,9 +13658,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -12997,11 +13708,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -13034,7 +13745,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -13054,9 +13765,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -13183,20 +13894,21 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -13246,7 +13958,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -13264,13 +13976,13 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.22",
 ]
 
 [[package]]
 name = "xcm"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "bounded-collections",
  "derivative",
@@ -13285,8 +13997,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-builder"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13300,14 +14012,15 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-weights",
  "xcm",
  "xcm-executor",
 ]
 
 [[package]]
 name = "xcm-executor"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -13326,13 +14039,13 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "0.9.40"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.40#a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f"
+version = "0.9.43"
+source = "git+https://github.com/paritytech/polkadot?branch=master#fa1c7b793b9af7caad286e2dd0488e47ba6056be"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -13351,32 +14064,31 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.20",
+ "time 0.3.22",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -13385,7 +14097,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+dependencies = [
+ "zstd-safe 6.0.5+zstd.1.5.4",
 ]
 
 [[package]]
@@ -13399,10 +14120,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
+name = "zstd-safe"
+version = "6.0.5+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+checksum = "d56d9e60b4b1758206c238a10165fbcae3ca37b01744e394c463463f6529d23b"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,20 @@
 panic = "unwind"
 
 [workspace]
-members = [
-	"node",
-	"runtime",
-]
+members = ["node", "runtime", "aleph-header-chain", "pallet-bridge-aleph"]
+
+[workspace.dependencies]
+# parity-bridges-common
+bp-test-utils = { git = "https://github.com/paritytech/parity-bridges-common", rev = "9afb6d15", default-features = false }
+bp-header-chain = { git = "https://github.com/paritytech/parity-bridges-common", rev = "9afb6d15", default-features = false }
+bp-runtime = { git = "https://github.com/paritytech/parity-bridges-common", rev = "9afb6d15", default-features = false }
+
+# substrate
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ local-network/polkadot: # Download the polkadot binary.
 	chmod +x local-network/polkadot
 
 local-network/zombienet-linux-x64: # Download the zombienet binary.
-	wget -nc https://github.com/paritytech/zombienet/releases/download/v1.3.39/zombienet-linux-x64 -P /tmp
+	wget -nc https://github.com/paritytech/zombienet/releases/download/v1.3.56/zombienet-linux-x64 -P /tmp
 	mv /tmp/zombienet-linux-x64 local-network/
 	chmod +x local-network/zombienet-linux-x64
 

--- a/aleph-header-chain/Cargo.toml
+++ b/aleph-header-chain/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "bp-aleph-header-chain"
+description = "Types and traits for chains using AlephBFT."
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+scale-info = { version = "2.6.0", default-features = false, features = [
+	"derive",
+] }
+serde = { version = "1.0", default-features = false, features = [
+	"alloc",
+	"derive",
+] }
+
+# Bridge dependencies
+bp-runtime = { workspace = true }
+bp-header-chain = { workspace = true }
+
+# Substrate Dependencies
+
+sp-application-crypto = { workspace = true }
+frame-support = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+hex = { version = "0.4", optional = true }
+
+# Test dependencies
+[dev-dependencies]
+bp-test-utils = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"bp-runtime/std",
+	"bp-header-chain/std",
+	"codec/std",
+	"frame-support/std",
+	"hex/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"hex/std",
+]

--- a/aleph-header-chain/Cargo.toml
+++ b/aleph-header-chain/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bp-aleph-header-chain"
 description = "Types and traits for chains using AlephBFT."
 version = "0.1.0"
-authors = ["Parity Technologies <admin@parity.io>"]
+authors = ["Cardinal Cryptography"]
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 

--- a/aleph-header-chain/src/aleph_justification.rs
+++ b/aleph-header-chain/src/aleph_justification.rs
@@ -1,0 +1,244 @@
+use codec::{Decode, Encode};
+use frame_support::PalletError;
+use sp_runtime::{traits::Header as HeaderT, RuntimeAppPublic, RuntimeDebug};
+use sp_std::vec::Vec;
+
+use crate::{AuthoritySet, AuthoritySignature};
+use scale_info::TypeInfo;
+
+#[derive(TypeInfo, PartialEq, Eq, Clone, Debug, Decode, Encode)]
+pub struct Signature(AuthoritySignature);
+
+pub type SignatureSet = Vec<Option<Signature>>;
+
+/// A proof of block finality, currently in the form of a sufficiently long list of signatures or a
+/// sudo signature of a block for emergency finalization.
+#[derive(TypeInfo, Clone, Encode, Decode, Debug, PartialEq, Eq)]
+pub enum AlephJustification {
+	CommitteeMultisignature(SignatureSet),
+	EmergencySignature(AuthoritySignature),
+}
+
+#[derive(Eq, Encode, Decode, PartialEq, Debug, Copy, Clone)]
+pub struct Version(pub u16);
+
+/// Actual on-chain justification format.
+#[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
+pub struct VersionedAlephJustification {
+	version: Version,
+	num_bytes: u16,
+	justification: AlephJustification,
+}
+
+#[derive(Eq, RuntimeDebug, PartialEq, Encode, Decode, TypeInfo, PalletError)]
+pub enum Error {
+	JustificationNotDecodable,
+	NotEnoughCorrectSignatures,
+	EmergencyFinalizerUsed,
+}
+
+pub fn verify_justification<Header: HeaderT>(
+	authority_set: &AuthoritySet,
+	header: &Header,
+	justification: &AlephJustification,
+) -> Result<(), Error> {
+	match justification {
+		AlephJustification::CommitteeMultisignature(signature_set) => {
+			let signature_count = signature_set
+				.iter()
+				.zip(authority_set.iter())
+				.filter_map(|(maybe_signature, authority)| {
+					Some((maybe_signature.as_ref()?, authority))
+				})
+				.filter(|(signature, authority)| {
+					authority.verify(&header.hash().encode(), &signature.0)
+				})
+				.count();
+
+			if signature_count < 2 * authority_set.len() / 3 + 1 {
+				return Err(Error::NotEnoughCorrectSignatures)
+			}
+
+			Ok(())
+		},
+		AlephJustification::EmergencySignature(_) => Err(Error::EmergencyFinalizerUsed),
+	}
+}
+
+#[cfg(feature = "std")]
+pub mod test_utils {
+	use super::*;
+	use crate::AuthorityId;
+	use hex::FromHex;
+	use sp_application_crypto::Pair;
+	use sp_runtime::{testing::Header, ConsensusEngineId};
+
+	pub type Seed = [u8; 32];
+	pub type Seeds = Vec<Seed>;
+
+	pub fn generate_seeds(size: usize) -> Seeds {
+		let mut seed = [0u8; 32];
+		let mut seeds = Vec::new();
+		for i in 0..size {
+			seed[i] = 1;
+			seeds.push(seed);
+		}
+		seeds
+	}
+
+	pub fn authority_id_from_seed(s: &Seed) -> AuthorityId {
+		pair_from_seed(s).public()
+	}
+
+	pub fn pair_from_seed(s: &Seed) -> crate::app::Pair {
+		crate::app::Pair::from_seed(s)
+	}
+
+	pub fn generate_authority_set(seeds: Seeds) -> AuthoritySet {
+		let mut authority_set = AuthoritySet::new();
+		for authority in seeds.iter() {
+			authority_set.push(authority_id_from_seed(authority));
+		}
+		authority_set
+	}
+
+	pub fn generate_signature_set(header: &Header, seeds: &Seeds) -> SignatureSet {
+		let mut signatures = Vec::new();
+		for authority in seeds.iter() {
+			let aleph_authority = pair_from_seed(authority);
+			let signature = aleph_authority.sign(&header.hash().encode());
+			signatures.push(Some(Signature(signature)));
+		}
+		signatures
+	}
+
+	pub fn generate_justification(header: &Header, seeds: &Seeds) -> AlephJustification {
+		let signature_set = generate_signature_set(header, seeds);
+		AlephJustification::CommitteeMultisignature(signature_set)
+	}
+
+	pub fn decode_from_hex<D: Decode>(data: &str) -> D {
+		Decode::decode(&mut &Vec::from_hex(data).unwrap()[..]).unwrap()
+	}
+
+	pub const AURA_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
+
+	pub fn raw_authorities_into_authority_set(raw_authorities: &[&str]) -> AuthoritySet {
+		let mut authorities = Vec::new();
+		println!("raw_authorities: {:?}", raw_authorities);
+		for raw_authority in raw_authorities {
+			authorities.push(decode_from_hex(raw_authority));
+		}
+		authorities
+	}
+
+	pub fn aleph_justification_from_hex(hex: &str) -> AlephJustification {
+		let encoded_justification: Vec<u8> = FromHex::from_hex(hex).unwrap();
+		let versioned_justification =
+			VersionedAlephJustification::decode(&mut encoded_justification.as_slice()).unwrap();
+		versioned_justification.justification
+	}
+}
+
+#[cfg(test)]
+pub mod tests {
+	use super::{test_utils::*, *};
+	use bp_test_utils::test_header;
+	use hex::FromHex;
+	use sp_runtime::{testing::Header, Digest, DigestItem};
+
+	#[test]
+	fn accepts_valid_justification() {
+		let header = test_header(5);
+		let justification = generate_justification(&header, &generate_seeds(4));
+		let authority_set = generate_authority_set(generate_seeds(4));
+
+		assert!(verify_justification(&authority_set, &header, &justification).is_ok());
+	}
+
+	#[test]
+	fn rejects_justification_with_too_little_signatures() {
+		let header = test_header(5);
+		let justification = generate_justification(&header, &generate_seeds(4));
+		let authority_set = generate_authority_set(generate_seeds(6));
+
+		assert!(verify_justification(&authority_set, &header, &justification).is_err());
+	}
+
+	const DEVNET_JUSTIFICATION: &str = "0300c60000100182e110ef61d591076351794f8d0927ddf0ee3aa4fcf0de6d3b4a07c9c0ce836a7d2efb1e7aef1ff645a1337a2b3eebccf80c78feba49e1f11997c636a6999f0d0001ecb430ade18767790b85280a134ae73dce133ee614f167c3f88f9fb3cf6a3c583f8e604410f3750bb86292167e86f06fd687fc1eb840c47cc27379a8e752d30e017b7e8504257b9e55dfb5f06a9e0a22d1b94aa8da0f202fc685ef6089d8a9286d011e687c8db69e7162b4b07ed55b35f837f22f93aacdb4e54dafe2d2dbde8509";
+	const DEVNET_AUTHORITIES: [&str; 4] = [
+		"bc3faef89f7b46c69088f4b3be1545a2dbb132a22bbfa9778625a924b0c38320",
+		"7e2dc59e0fcf3ece8a37a8672952fbccb4b73403069901fb5804ac2e36a90d5a",
+		"c2e071ddd5c993e3498ccd5e38a5a77b4d94848d6b066bc9391ac4e3be84ce5c",
+		"7e0a8df85cf67e1e83eacb7690245872a571ce5d37bd5cb761ec98da4f3238d4",
+	];
+
+	// Block 51730103
+	const MAINNET_JUSTIFICATION: &str = "03009002003801752af5d2d57c25657cf083014c65eb39d18a4eeba5ca4a1ffeee378df14298ef449f9b076a3f5918de1e774410a52fb38f0fd5e70ba44dfea1453647388b94060112cb082077986f0e79bb12a69d9fa483f99f8a552e5124623a4e8a14ff324f9ba33d9b0cc11d9c773c8ee6d830a334c012f3c9b1036f44ba08f0fe5e7b1e540f01c5906221eec48d57d992573cebc1e6861f1e7e572d1d0d47328dd417361cb53d71864407246a6c0f575e67471e6692a3066d1a5787817645b9f1e5dc57fb2a0d000158b8d87262541a2f73d6c311657f74234203a3650ac442acf99bf4e1600486bb1e5849c6ac204c58c1120189c8e3c76918c564ec2a0468365751f15591580f0d0114e28c22ff3cee483567ae2fc0e4aab6386e5cba24eb3c2866b0e2245ad1a5bb70a0714e807e0b903ef58463792595a6d6a4e5fe58c3c0ad118eb031a32c7b060001c10be8f8665c804552dd3af729724422841fb47f8dfbb5487935ca86bdee3489bc03ea4c47c022462c19bb668c913392192e27f0bcc8538edf61d076c772b80600019ebf0579cd074ce2385326ad8dfadb720e14365c9cb588d56776ce9fbf73d3a4e30671fec68c6a1cee052d19ef5e018e53a44222063379f754e8aa80ea54cd05012f4b3f8a0845134fa599aea859a9c09c020712f31bf24a6e98587bf44d89f3d854df2a96c6af8ddc81885dd7c0d26f64a69f9b0da418025a6b42d955d97dcd0301e4094b019782509277dbe7969b1cb9ae22f65b7c33c32542b22ffe0d179a7661ffa3743747cf19870a1491406adb8438d11c70e5732655a340344a1c0686d20701f42cb05c7793f8055bb8c0d8e872426f2293a2cc54898548a0d71b2906caa2c4c5d5af502331c9b7c5d7e5f587414a6b5a00f92cff843d44eebb81d84a592e0400";
+	const MAINNET_AUTHORITIES: [&str; 14] = [
+		"3e1f808aba722e8c2b605186d525330fc0602448aa1a0e4095db3e691e82aa53",
+		"4e9800a7078b680ba72b0f077d6803c3d35ccdcba15b618542801a5cdf5c949b",
+		"55f42ea5496bd242dc59f3a299ebc4f3ad6ea1b47b745abdda2b3a6129cf0afe",
+		"8f725daf2944ef12357e298058c317a409d313d5379fee88abddd2967b0c02da",
+		"37371d98a2d7d88096414e55e861e06a07ba7645c49d446cc5e414bb3c00d456",
+		"749e7ca3ff95b3c92608500525f33071cd2ce4e592ba9535a6eb7bac1b667faa",
+		"c86669783d7c1c1516dd7bd70dcc893232c9a73b4e1095557ef3a929d324904a",
+		"bc16685f99c1ebfbaeb0bb1b1f6b81f078977cfb5418c4e125b8a989817d9fcf",
+		"8e6efcceba526685383b74cc53eb09f8fe2e6bcb9988e2bc618ead55251f7e97",
+		"def643f576925be43e4e6f139c6d6787b3da8f637a3d29fef01ccaf24d82259e",
+		"fb35011223beff7e82a7932bfb9f5ad0a774c9812189b0bb8aec3389b515eafc",
+		"10ae993223432b051b8ecf175c2ab0ef72186b540d8abd402b0568329a5d3b03",
+		"0c5b46f7d638edf0e76e85d451096f6bf361a476b43d61f177d8cf0253588cb1",
+		"f4ad895cce6857c6f8b955d55907969ee6a8f177187921e771cee52bd7b2b800",
+	];
+
+	#[test]
+	fn devnet_justification_decodes() {
+		let encoded_justification: Vec<u8> = FromHex::from_hex(DEVNET_JUSTIFICATION).unwrap();
+		assert!(VersionedAlephJustification::decode(&mut encoded_justification.as_slice()).is_ok());
+	}
+
+	#[test]
+	fn mainnet_justification_decodes() {
+		let encoded_justification: Vec<u8> = FromHex::from_hex(MAINNET_JUSTIFICATION).unwrap();
+		assert!(VersionedAlephJustification::decode(&mut encoded_justification.as_slice()).is_ok());
+	}
+
+	#[test]
+	fn devnet_justification_is_valid() {
+		let authority_set = raw_authorities_into_authority_set(&DEVNET_AUTHORITIES);
+		let justification = aleph_justification_from_hex(DEVNET_JUSTIFICATION);
+		let header = Header::new(
+			49,
+			decode_from_hex("bf45a153b83c7981aede86e12cd072a1fde518dda899b7f9a5b222eaa432b9a0"),
+			decode_from_hex("96ea6b88d102208f8072513b6015ff32a4070de19c5988e040d7710e5919ce64"),
+			decode_from_hex("5bc9cb5341a1ae9a282208f19d68333f18c29b7096eecdf4983b78de642266d7"), 
+			Digest {
+				logs: vec![
+				DigestItem::PreRuntime(AURA_ENGINE_ID, FromHex::from_hex("beeda36400000000").unwrap()), 
+				DigestItem::Seal(AURA_ENGINE_ID, FromHex::from_hex("746d6432f2d81c9710b70bcefda2c6e584ab67f09d59c17e69fce3d07c74d80589032511258587f1107eb3ac90b6166b1ecac7d558739a07a70e864aef1c8488").unwrap())
+			]}
+		);
+
+		assert!(verify_justification(&authority_set, &header, &justification).is_ok());
+	}
+
+	#[test]
+	fn mainnet_justification_is_valid() {
+		let authority_set = raw_authorities_into_authority_set(&MAINNET_AUTHORITIES);
+		let justification = aleph_justification_from_hex(MAINNET_JUSTIFICATION);
+		let header = Header::new(
+			51730103,
+			decode_from_hex("78d422f744c6207f40ceb5504021803a7551c03e74b3e2c847df2a052b565942"),
+			decode_from_hex("ffa33bb51a943ebd44426569cbfc901ca1e37a8f06652cf5cff20473cd980690"),
+			decode_from_hex("de7ce2d09b3d3b6decfdf9a1e8b0582d413642d8edd4d326a5677f6222027028"), 
+			Digest {
+				logs: vec![
+				DigestItem::PreRuntime(AURA_ENGINE_ID, FromHex::from_hex("b1b8a26400000000").unwrap()), 
+				DigestItem::Seal(AURA_ENGINE_ID, FromHex::from_hex("220b93bbbb5af5352c2da639536b2c0ac33e6cfe4d765846f33838344e24fb54373092c0b16671414d431828ddb771552e17a89a67928e88e5ac343a0021548e").unwrap())
+			]}
+		);
+
+		assert!(verify_justification(&authority_set, &header, &justification).is_ok());
+	}
+}

--- a/aleph-header-chain/src/lib.rs
+++ b/aleph-header-chain/src/lib.rs
@@ -1,0 +1,94 @@
+// Copyright 2023 Cardinal Cryptography
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use bp_runtime::{BasicOperatingMode, Chain, HeaderOf};
+use codec::{Decode, Encode};
+use core::{clone::Clone, cmp::Eq, default::Default, fmt::Debug};
+use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
+use sp_runtime::{traits::Header as HeaderT, ConsensusEngineId, Digest, KeyTypeId, RuntimeDebug};
+use sp_std::{boxed::Box, vec::Vec};
+
+pub mod aleph_justification;
+
+pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"alp0");
+pub const ALEPH_ENGINE_ID: ConsensusEngineId = *b"FRNK";
+
+mod app {
+	use sp_application_crypto::{app_crypto, ed25519};
+	app_crypto!(ed25519, crate::KEY_TYPE);
+}
+
+sp_application_crypto::with_pair! {
+	pub type AuthorityPair = app::Pair;
+}
+
+pub type AuthorityId = app::Public;
+pub type AuthoritySignature = app::Signature;
+pub type AuthoritySet = Vec<AuthorityId>;
+
+/// Consensus log item for Aleph.
+#[cfg_attr(feature = "std", derive(Serialize))]
+#[derive(Decode, Encode, PartialEq, Eq, Clone, sp_runtime::RuntimeDebug)]
+pub enum ConsensusLog {
+	/// Change of the authorities.
+	#[codec(index = 1)]
+	AlephAuthorityChange(Vec<AuthorityId>),
+}
+
+// Helper method for reading Aleph's consensus log.
+pub fn get_authority_change(digest: &Digest) -> Option<AuthoritySet> {
+	use sp_runtime::generic::OpaqueDigestItemId;
+	let id = OpaqueDigestItemId::Consensus(&ALEPH_ENGINE_ID);
+	let filter_log = |log: ConsensusLog| match log {
+		ConsensusLog::AlephAuthorityChange(change) => Some(change),
+	};
+
+	digest.convert_first(|l| l.try_to(id).and_then(filter_log))
+}
+
+/// Data required for initializing the Aleph bridge pallet.
+///
+/// The bridge needs to know where to start its sync from, and this provides that initial context.
+#[derive(
+	Default, Encode, Decode, RuntimeDebug, PartialEq, Eq, Clone, TypeInfo, Serialize, Deserialize,
+)]
+pub struct InitializationData<H: HeaderT> {
+	/// The header from which we should start syncing.
+	pub header: Box<H>,
+	/// The initial authorities of the pallet.
+	pub authority_list: AuthoritySet,
+	/// Pallet operating mode.
+	pub operating_mode: BasicOperatingMode,
+}
+
+/// A minimized version of `pallet-bridge-aleph::Call` that can be used without a runtime.
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
+#[allow(non_camel_case_types)]
+pub enum BridgeAlephCall<Header: HeaderT> {
+	#[codec(index = 1)]
+	initialize { init_data: InitializationData<Header> },
+}
+
+pub type BridgeAlephCallOf<C> = BridgeAlephCall<HeaderOf<C>>;
+
+pub trait ChainWithAleph: Chain {
+	const WITH_CHAIN_ALEPH_PALLET_NAME: &'static str;
+	const MAX_AUTHORITIES_COUNT: u32;
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clap = { version = "4.3.19", features = ["derive"] }
+clap = { version = "4.1.14", features = ["derive"] }
 log = "0.4.17"
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.159", features = ["derive"] }
@@ -20,59 +20,59 @@ jsonrpsee = { version = "0.16.2", features = ["server"] }
 aleph-parachain-runtime = { path = "../runtime" }
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-network-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-network-sync = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-sysinfo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.40" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network-common = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network-sync = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-sysinfo = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true , branch = "master" }
 
 # Polkadot
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.40" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.40" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.40" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
 
 # Cumulus
-cumulus-client-cli = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
-cumulus-client-consensus-aura = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
-cumulus-client-consensus-common = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
-cumulus-client-network = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
-cumulus-client-service = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
-cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40" }
+cumulus-client-cli = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
+cumulus-client-consensus-aura = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
+cumulus-client-consensus-common = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
+cumulus-client-network = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
+cumulus-client-service = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus.git", branch = "master" }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = []
@@ -84,5 +84,5 @@ runtime-benchmarks = [
 ]
 try-runtime = [
 	"try-runtime-cli/try-runtime",
-	"aleph-parachain-runtime/try-runtime",
+	"aleph-parachain-runtime/try-runtime"
 ]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,4 +1,6 @@
-use aleph_parachain_runtime::{AccountId, AuraId, Signature, SudoConfig, EXISTENTIAL_DEPOSIT};
+use aleph_parachain_runtime::{
+	AccountId, AuraId, RuntimeGenesisConfig, Signature, EXISTENTIAL_DEPOSIT,
+};
 use cumulus_primitives_core::ParaId;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
@@ -7,15 +9,14 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type ChainSpec =
-	sc_service::GenericChainSpec<aleph_parachain_runtime::GenesisConfig, Extensions>;
+pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig, Extensions>;
 
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-	TPublic::Pair::from_string(&format!("//{seed}"), None)
+	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
 }
@@ -181,8 +182,8 @@ fn testnet_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	endowed_accounts: Vec<AccountId>,
 	id: ParaId,
-) -> aleph_parachain_runtime::GenesisConfig {
-	aleph_parachain_runtime::GenesisConfig {
+) -> RuntimeGenesisConfig {
+	RuntimeGenesisConfig {
 		system: aleph_parachain_runtime::SystemConfig {
 			code: aleph_parachain_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
@@ -218,6 +219,5 @@ fn testnet_genesis(
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
 		},
 		transaction_payment: Default::default(),
-		sudo: SudoConfig { key: Some(get_account_id_from_seed::<sr25519::Public>("Alice")) },
 	}
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -93,7 +93,11 @@ impl RelayChainCli {
 	) -> Self {
 		let extension = crate::chain_spec::Extensions::try_get(&*para_config.chain_spec);
 		let chain_id = extension.map(|e| e.relay_chain.clone());
-		let base_path = para_config.base_path.as_ref().map(|x| x.path().join("polkadot"));
-		Self { base_path, chain_id, base: clap::Parser::parse_from(relay_chain_args) }
+		let base_path = para_config.base_path.path().join("polkadot");
+		Self {
+			base_path: Some(base_path),
+			chain_id,
+			base: clap::Parser::parse_from(relay_chain_args),
+		}
 	}
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -166,7 +166,7 @@ pub fn run() -> Result<()> {
 					&polkadot_cli,
 					config.tokio_handle.clone(),
 				)
-				.map_err(|err| format!("Relay chain argument error: {err}"))?;
+				.map_err(|err| format!("Relay chain argument error: {}", err))?;
 
 				cmd.run(config, polkadot_config)
 			})
@@ -277,13 +277,13 @@ pub fn run() -> Result<()> {
 
 				let state_version = Cli::native_runtime_version(&config.chain_spec).state_version();
 				let block: Block = generate_genesis_block(&*config.chain_spec, state_version)
-					.map_err(|e| format!("{e:?}"))?;
+					.map_err(|e| format!("{:?}", e))?;
 				let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
 				let tokio_handle = config.tokio_handle.clone();
 				let polkadot_config =
 					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
-						.map_err(|err| format!("Relay chain argument error: {err}"))?;
+						.map_err(|err| format!("Relay chain argument error: {}", err))?;
 
 				info!("Parachain id: {:?}", id);
 				info!("Parachain Account: {}", parachain_account);
@@ -312,6 +312,10 @@ pub fn run() -> Result<()> {
 impl DefaultConfigurationValues for RelayChainCli {
 	fn p2p_listen_port() -> u16 {
 		30334
+	}
+
+	fn rpc_listen_port() -> u16 {
+		9945
 	}
 
 	fn prometheus_listen_port() -> u16 {
@@ -384,6 +388,10 @@ impl CliConfiguration<Self> for RelayChainCli {
 
 	fn rpc_methods(&self) -> Result<sc_service::config::RpcMethods> {
 		self.base.base.rpc_methods()
+	}
+
+	fn rpc_max_connections(&self) -> Result<u32> {
+		self.base.base.rpc_max_connections()
 	}
 
 	fn rpc_cors(&self, is_dev: bool) -> Result<Option<Vec<String>>> {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -22,18 +22,21 @@ use cumulus_relay_chain_interface::RelayChainInterface;
 // Substrate Imports
 use frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE;
 use sc_consensus::ImportQueue;
-use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
-use sc_network::NetworkBlock;
+use sc_executor::{
+	HeapAllocStrategy, NativeElseWasmExecutor, NativeExecutionDispatch, WasmExecutor,
+	DEFAULT_HEAP_ALLOC_STRATEGY,
+};
+use sc_network::{config::FullNetworkConfiguration, NetworkBlock};
 use sc_network_sync::SyncingService;
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
-use sp_keystore::SyncCryptoStorePtr;
+use sp_keystore::KeystorePtr;
 use substrate_prometheus_endpoint::Registry;
 
 // Our native executor instance.
-pub struct ParachainNativeExecutor;
+pub struct ExecutorDispatch;
 
-impl NativeExecutionDispatch for ParachainNativeExecutor {
+impl NativeExecutionDispatch for ExecutorDispatch {
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
 
 	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
@@ -44,12 +47,11 @@ impl NativeExecutionDispatch for ParachainNativeExecutor {
 		aleph_parachain_runtime::native_version()
 	}
 }
-pub type ParachainRuntimeExecutor = ParachainNativeExecutor;
+pub type ParachainRuntimeExecutor = ExecutorDispatch;
 type ParachainClient =
 	TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<ParachainRuntimeExecutor>>;
 type ParachainBackend = TFullBackend<Block>;
 type ParachainBlockImport = TParachainBlockImport<Block, Arc<ParachainClient>, ParachainBackend>;
-type ParachainExecutor = NativeElseWasmExecutor<ParachainNativeExecutor>;
 
 /// Starts a `ServiceBuilder` for a full service.
 ///
@@ -80,12 +82,19 @@ pub fn new_partial(
 		})
 		.transpose()?;
 
-	let executor = ParachainExecutor::new(
-		config.wasm_method,
-		config.default_heap_pages,
-		config.max_runtime_instances,
-		config.runtime_cache_size,
-	);
+	let heap_pages = config
+		.default_heap_pages
+		.map_or(DEFAULT_HEAP_ALLOC_STRATEGY, |h| HeapAllocStrategy::Static { extra_pages: h as _ });
+	let executor =
+		sc_executor::NativeElseWasmExecutor::<ParachainRuntimeExecutor>::new_with_wasm_executor(
+			WasmExecutor::builder()
+				.with_execution_method(config.wasm_method)
+				.with_onchain_heap_alloc_strategy(heap_pages)
+				.with_offchain_heap_alloc_strategy(heap_pages)
+				.with_max_runtime_instances(config.max_runtime_instances)
+				.with_runtime_cache_size(config.runtime_cache_size)
+				.build(),
+		);
 
 	let (client, backend, keystore_container, task_manager) =
 		sc_service::new_full_parts::<Block, RuntimeApi, _>(
@@ -168,10 +177,12 @@ async fn start_node_impl(
 	let prometheus_registry = parachain_config.prometheus_registry().cloned();
 	let transaction_pool = params.transaction_pool.clone();
 	let import_queue_service = params.import_queue.service();
+	let net_config = FullNetworkConfiguration::new(&parachain_config.network);
 
 	let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
 		build_network(BuildNetworkParams {
 			parachain_config: &parachain_config,
+			net_config,
 			client: client.clone(),
 			transaction_pool: transaction_pool.clone(),
 			para_id,
@@ -211,7 +222,7 @@ async fn start_node_impl(
 		transaction_pool: transaction_pool.clone(),
 		task_manager: &mut task_manager,
 		config: parachain_config,
-		keystore: params.keystore_container.sync_keystore(),
+		keystore: params.keystore_container.keystore(),
 		backend,
 		network: network.clone(),
 		sync_service: sync_service.clone(),
@@ -262,7 +273,7 @@ async fn start_node_impl(
 			relay_chain_interface.clone(),
 			transaction_pool,
 			sync_service.clone(),
-			params.keystore_container.sync_keystore(),
+			params.keystore_container.keystore(),
 			force_authoring,
 			para_id,
 		)?;
@@ -281,6 +292,7 @@ async fn start_node_impl(
 			collator_key: collator_key.expect("Command line arguments do not allow this. qed"),
 			relay_chain_slot_duration,
 			recovery_handle: Box::new(overseer_handle),
+			sync_service,
 		};
 
 		start_collator(params).await?;
@@ -294,6 +306,7 @@ async fn start_node_impl(
 			relay_chain_slot_duration,
 			import_queue: import_queue_service,
 			recovery_handle: Box::new(overseer_handle),
+			sync_service,
 		};
 
 		start_full_node(params)?;
@@ -352,7 +365,7 @@ fn build_consensus(
 	relay_chain_interface: Arc<dyn RelayChainInterface>,
 	transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
 	sync_oracle: Arc<SyncingService<Block>>,
-	keystore: SyncCryptoStorePtr,
+	keystore: KeystorePtr,
 	force_authoring: bool,
 	para_id: ParaId,
 ) -> Result<Box<dyn ParachainConsensus<Block>>, sc_service::Error> {

--- a/pallet-bridge-aleph/Cargo.toml
+++ b/pallet-bridge-aleph/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "pallet-bridge-aleph"
+version = "0.1.0"
+authors = ["Cardinal Cryptography"]
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+log = { version = "0.4.17", default-features = false }
+scale-info = { version = "2.6.0", default-features = false, features = [
+	"derive",
+] }
+
+# Bridge Dependencies
+bp-runtime = { workspace = true }
+bp-header-chain = { workspace = true }
+bp-aleph-header-chain = { path = "../aleph-header-chain", default-features = false }
+
+# Substrate Dependencies
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+sp-trie = { workspace = true }
+
+[dev-dependencies]
+bp-test-utils = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+hex = "0.4"
+
+[features]
+default = ["std"]
+std = [
+	"bp-header-chain/std",
+	"bp-aleph-header-chain/std",
+	"bp-runtime/std",
+	"bp-test-utils/std",
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"scale-info/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"sp-trie/std",
+]
+try-runtime = ["frame-support/try-runtime", "frame-system/try-runtime"]

--- a/pallet-bridge-aleph/src/lib.rs
+++ b/pallet-bridge-aleph/src/lib.rs
@@ -1,0 +1,802 @@
+// Copyright 2023 Cardinal Cryptography
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+// This pallet is largely based on the `GRANDPA` pallet, but is changed to work with AlephBFT
+
+//! Aleph bridging Pallet
+//!
+//! This pallet is an on-chain AlephBFT light client.
+//!
+//! Right now, it does not support submiting finality proofs, but only
+//! being directly initialized with a header and authority set.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::large_enum_variant)]
+
+use bp_aleph_header_chain::{
+	aleph_justification::{verify_justification, AlephJustification},
+	get_authority_change, ChainWithAleph, InitializationData,
+};
+use bp_header_chain::{HeaderChain, StoredHeaderData, StoredHeaderDataBuilder};
+use bp_runtime::{BlockNumberOf, HashOf, HeaderId, HeaderOf, OwnedBridgeModule};
+use frame_support::sp_runtime::traits::Header;
+
+#[cfg(test)]
+mod mock;
+mod storage_types;
+
+use storage_types::StoredAuthoritySet;
+
+// Re-export in crate namespace for `construct_runtime!`
+pub use pallet::*;
+
+pub const LOG_TARGET: &str = "runtime::bridge-aleph";
+
+pub type BridgedChain<T> = <T as Config>::BridgedChain;
+pub type BridgedBlockNumber<T> = BlockNumberOf<<T as Config>::BridgedChain>;
+pub type BridgedBlockHash<T> = HashOf<<T as Config>::BridgedChain>;
+pub type BridgedBlockId<T> = HeaderId<BridgedBlockHash<T>, BridgedBlockNumber<T>>;
+pub type BridgedHeader<T> = HeaderOf<<T as Config>::BridgedChain>;
+pub type BridgedStoredHeaderData<T> = StoredHeaderData<BridgedBlockNumber<T>, BridgedBlockHash<T>>;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use bp_runtime::BasicOperatingMode;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type BridgedChain: ChainWithAleph;
+		#[pallet::constant]
+		type HeadersToKeep: Get<u32>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			Weight::zero()
+		}
+	}
+
+	impl<T: Config> OwnedBridgeModule<T> for Pallet<T> {
+		const LOG_TARGET: &'static str = LOG_TARGET;
+		type OwnerStorage = PalletOwner<T>;
+		type OperatingMode = BasicOperatingMode;
+		type OperatingModeStorage = PalletOperatingMode<T>;
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Verify a target header is finalized according to the given finality proof.
+		///
+		/// It verifies the finality proof against the current authority set held in storage.
+		/// Rejects headers with number lower than the best known finalized header.
+		///
+		/// If successful in verification, it updates the best finalized header.
+		///
+		/// The call fails if:
+		/// - the pallet is halted;
+		/// - the pallet knows better header than the `finality_target`;
+		/// - justification is invalid;
+		///
+		/// For now, weights are incorrect.
+		#[pallet::call_index(0)]
+		// TODO: Set correct weights
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
+		pub fn submit_finality_proof(
+			_origin: OriginFor<T>,
+			header: BridgedHeader<T>,
+			justification: AlephJustification,
+		) -> DispatchResultWithPostInfo {
+			Self::ensure_not_halted().map_err(Error::<T>::BridgeModule)?;
+
+			// Check of obsolete header
+			if let Some(best_finalized_block) = Self::best_finalized() {
+				if header.number() <= &best_finalized_block.number() {
+					log::debug!(
+						target: LOG_TARGET,
+						"Skipping import of an old header: {:?}.",
+						header.hash()
+					);
+					return Err(Error::<T>::OldHeader.into())
+				}
+			}
+
+			// Check justification
+			let authority_set = <CurrentAuthoritySet<T>>::get();
+			verify_justification::<BridgedHeader<T>>(
+				&authority_set.into(),
+				&header,
+				&justification,
+			)
+			.map_err(|verification_err| Error::<T>::InvalidJustification(verification_err))?;
+
+			// Check for authority set change digest
+			Self::try_enact_authority_change(&header)?;
+
+			// Insert new header
+			Self::insert_header(header.clone());
+			log::info!(
+				target: LOG_TARGET,
+				"Successfully imported finalized header with hash {:?}!",
+				header.hash()
+			);
+
+			Self::deposit_event(Event::UpdatedBestFinalizedHeader {
+				number: *header.number(),
+				hash: header.hash(),
+			});
+
+			Ok(().into())
+		}
+
+		/// Bootstrap the bridge pallet with an initial header and authority set from which to sync.
+		///
+		/// The initial configuration provided does not need to be the genesis header of the bridged
+		/// chain, it can be any arbitrary header.
+		///
+		/// This function is only allowed to be called by a root origin and writes to storage
+		/// with practically no checks in terms of the validity of the data. It is important that
+		/// you ensure that valid data is being passed in.
+		///
+		/// Difference with GRANDPA: This function can only be called by root.
+		///
+		/// Note: It cannot be called once the bridge has been initialized.
+		/// To reinitialize the bridge, you must reinitialize the pallet.
+		#[pallet::call_index(1)]
+		#[pallet::weight((T::DbWeight::get().reads_writes(3, 7), DispatchClass::Operational))]
+		pub fn initialize(
+			origin: OriginFor<T>,
+			init_data: super::InitializationData<BridgedHeader<T>>,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+
+			// Ensure that the bridge has not been already initialized.
+			let init_allowed = !<BestFinalized<T>>::exists();
+			ensure!(init_allowed, <Error<T>>::AlreadyInitialized);
+
+			// Initialize the bridge.
+			Self::initialize_bridge(init_data.clone())?;
+
+			log::info!(
+				target: LOG_TARGET,
+				"Pallet has been initialized with the following parameters: {:?}",
+				init_data
+			);
+
+			Ok(().into())
+		}
+
+		/// Change `PalletOwner`.
+		///
+		/// May only be called either by root or current `PalletOwner`.
+		#[pallet::call_index(2)]
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
+		pub fn set_owner(origin: OriginFor<T>, new_owner: Option<T::AccountId>) -> DispatchResult {
+			<Self as OwnedBridgeModule<_>>::set_owner(origin, new_owner)
+		}
+
+		/// Halt or resume all pallet operations.
+		///
+		/// May only be called either by root, or by `PalletOwner`.
+		#[pallet::call_index(3)]
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
+		pub fn set_operating_mode(
+			origin: OriginFor<T>,
+			operating_mode: BasicOperatingMode,
+		) -> DispatchResult {
+			<Self as OwnedBridgeModule<_>>::set_operating_mode(origin, operating_mode)
+		}
+	}
+
+	/// Hash and number of the best finalized header.
+	#[pallet::storage]
+	#[pallet::getter(fn best_finalized)]
+	pub type BestFinalized<T: Config> = StorageValue<_, BridgedBlockId<T>, OptionQuery>;
+
+	/// A ring buffer of imported hashes. Ordered by insertion time.
+	#[pallet::storage]
+	pub(super) type ImportedHashes<T: Config> = StorageMap<
+		Hasher = Identity,
+		Key = u32,
+		Value = BridgedBlockHash<T>,
+		MaxValues = HeadersToKeepOption<T>,
+	>;
+
+	/// Current ring buffer position.
+	#[pallet::storage]
+	pub(super) type ImportedHashesPointer<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+	/// A ring buffer for relevant fields of imported headers.
+	#[pallet::storage]
+	pub type ImportedHeaders<T: Config> = StorageMap<
+		Hasher = Identity,
+		Key = BridgedBlockHash<T>,
+		Value = BridgedStoredHeaderData<T>,
+		MaxValues = HeadersToKeepOption<T>,
+	>;
+
+	/// The current Aleph Authority set.
+	#[pallet::storage]
+	pub type CurrentAuthoritySet<T: Config> = StorageValue<_, StoredAuthoritySet<T>, ValueQuery>;
+
+	/// Optional pallet owner.
+	///
+	/// Pallet owner has the right to halt all pallet operations and then resume them.
+	#[pallet::storage]
+	pub type PalletOwner<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
+	/// The current operating mode of the pallet.
+	///
+	/// Depending on the mode either all, or no transactions will be allowed.
+	#[pallet::storage]
+	pub type PalletOperatingMode<T: Config> = StorageValue<_, BasicOperatingMode, ValueQuery>;
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub owner: Option<T::AccountId>,
+		pub init_data: Option<super::InitializationData<BridgedHeader<T>>>,
+	}
+
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self { owner: None, init_data: None }
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			if let Some(ref owner) = self.owner {
+				<PalletOwner<T>>::put(owner);
+			}
+
+			if let Some(init_data) = self.init_data.clone() {
+				Pallet::<T>::initialize_bridge(init_data).expect("genesis config is correct; qed");
+			} else {
+				// Since the bridge hasn't been initialized we shouldn't allow anyone to perform
+				// transactions.
+				<PalletOperatingMode<T>>::put(BasicOperatingMode::Halted);
+			}
+		}
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Best finalized chain header has been updated to the header with given number and hash.
+		UpdatedBestFinalizedHeader { number: BridgedBlockNumber<T>, hash: BridgedBlockHash<T> },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The given justification is invalid for the given header.
+		InvalidJustification(bp_aleph_header_chain::aleph_justification::Error),
+		/// The header being imported is older than the best finalized header known to the pallet.
+		OldHeader,
+		/// The pallet is not yet initialized.
+		NotInitialized,
+		/// The pallet has already been initialized.
+		AlreadyInitialized,
+		/// Too many authorities in the set.
+		TooManyAuthoritiesInSet,
+		/// Error generated by the `OwnedBridgeModule` trait.
+		BridgeModule(bp_runtime::OwnedBridgeModuleError),
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Import a previously verified header to the storage.
+		///
+		/// Note this function solely takes care of updating the storage and pruning old entries,
+		/// but does not verify the validity of such import.
+		fn insert_header(header: BridgedHeader<T>) {
+			let hash = header.hash();
+			let index = <ImportedHashesPointer<T>>::get();
+			let header_to_prune = <ImportedHashes<T>>::try_get(index).ok();
+			<BestFinalized<T>>::put(HeaderId(*header.number(), hash));
+			<ImportedHeaders<T>>::insert(hash, header.build());
+			<ImportedHashes<T>>::insert(index, hash);
+
+			// Update ring buffer pointer and remove old header.
+			<ImportedHashesPointer<T>>::put((index + 1) % T::HeadersToKeep::get());
+			if let Some(pruned_header_hash) = header_to_prune {
+				log::debug!(target: LOG_TARGET, "Pruning old header: {:?}.", pruned_header_hash);
+				<ImportedHeaders<T>>::remove(pruned_header_hash);
+			}
+		}
+
+		/// Since this writes to storage with no real checks this should only be used in functions
+		/// that were called by a trusted origin.
+		fn initialize_bridge(
+			init_params: super::InitializationData<BridgedHeader<T>>,
+		) -> Result<(), Error<T>> {
+			let super::InitializationData { header, authority_list, operating_mode } = init_params;
+			let authority_set_length = authority_list.len();
+			let authority_set = StoredAuthoritySet::<T>::try_new(authority_list)
+			.map_err(|err| {
+				log::error!(
+					target: LOG_TARGET,
+					"Failed to initialize bridge. Number of authorities in the set {} is larger than the configured value {}",
+					authority_set_length,
+					T::BridgedChain::MAX_AUTHORITIES_COUNT,
+				);
+				err
+			})?;
+
+			<ImportedHashesPointer<T>>::put(0);
+			Self::insert_header(*header);
+
+			<CurrentAuthoritySet<T>>::put(authority_set);
+			<PalletOperatingMode<T>>::put(operating_mode);
+
+			Ok(())
+		}
+
+		/// Check the given header for an authority set change. If a change
+		/// is found it will be enacted immediately.
+		fn try_enact_authority_change(header: &BridgedHeader<T>) -> Result<(), Error<T>> {
+			if let Some(change) = get_authority_change(header.digest()) {
+				let next_authorities = StoredAuthoritySet::<T>::try_new(change)?;
+				<CurrentAuthoritySet<T>>::put(&next_authorities);
+
+				log::info!(
+					target: LOG_TARGET,
+					"New authorities are: {:?}",
+					next_authorities,
+				);
+			};
+
+			Ok(())
+		}
+	}
+
+	/// Adapter for using `Config::HeadersToKeep` as `MaxValues` bound in our storage maps.
+	/// We need to use it since `StorageMap` implementation expects Get<Option<u32>> for
+	/// `MaxValues`.
+	pub struct HeadersToKeepOption<T>(PhantomData<T>);
+
+	impl<T: Config> Get<Option<u32>> for HeadersToKeepOption<T> {
+		fn get() -> Option<u32> {
+			Some(T::HeadersToKeep::get())
+		}
+	}
+
+	// Tests for the pallet.
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+		use crate::mock::{
+			run_test, test_header, Aleph, RuntimeOrigin, System, TestHeader, TestRuntime,
+		};
+		use bp_aleph_header_chain::{
+			aleph_justification::test_utils::{
+				aleph_justification_from_hex, decode_from_hex, raw_authorities_into_authority_set,
+				AURA_ENGINE_ID,
+			},
+			AuthorityId, AuthoritySet, ALEPH_ENGINE_ID,
+		};
+		use bp_runtime::{BasicOperatingMode, UnverifiedStorageProof};
+		use bp_test_utils::{generate_owned_bridge_module_tests, Account, ALICE, BOB, CHARLIE};
+		use frame_support::{
+			assert_noop, assert_ok, dispatch::PostDispatchInfo, storage::generator::StorageValue,
+		};
+		use hex::FromHex;
+		use sp_core::crypto::UncheckedFrom;
+		use sp_runtime::{Digest, DigestItem, DispatchError};
+
+		fn authority_id_from_account(account: Account) -> AuthorityId {
+			UncheckedFrom::unchecked_from(account.public().to_bytes())
+		}
+
+		fn into_authority_set(accounts: Vec<Account>) -> Vec<AuthorityId> {
+			accounts.into_iter().map(|a| authority_id_from_account(a)).collect()
+		}
+
+		fn initialize_with_custom_data(init_data: InitializationData<TestHeader>) {
+			System::set_block_number(1);
+			System::reset_events();
+
+			assert_ok!(init_with_origin(RuntimeOrigin::root(), init_data));
+		}
+
+		fn test_init_data() -> InitializationData<TestHeader> {
+			let genesis = test_header(0);
+			let authority_list = into_authority_set(vec![ALICE, BOB, CHARLIE]);
+			let operating_mode = BasicOperatingMode::Normal;
+			InitializationData { header: Box::new(genesis), authority_list, operating_mode }
+		}
+
+		fn initialize_substrate_bridge() {
+			System::set_block_number(1);
+			System::reset_events();
+
+			let init_data = test_init_data();
+			assert_ok!(init_with_origin(RuntimeOrigin::root(), init_data));
+		}
+
+		fn init_with_origin(
+			origin: RuntimeOrigin,
+			init_data: InitializationData<TestHeader>,
+		) -> Result<
+			InitializationData<TestHeader>,
+			sp_runtime::DispatchErrorWithPostInfo<PostDispatchInfo>,
+		> {
+			Aleph::initialize(origin, init_data.clone()).map(|_| init_data)
+		}
+
+		generate_owned_bridge_module_tests!(BasicOperatingMode::Normal, BasicOperatingMode::Halted);
+
+		#[test]
+		fn init_root_origin_can_initialize_pallet() {
+			run_test(|| {
+				assert_ok!(init_with_origin(RuntimeOrigin::root(), test_init_data()));
+			})
+		}
+
+		#[test]
+		fn init_normal_user_cannot_initialize_pallet() {
+			run_test(|| {
+				assert_noop!(
+					init_with_origin(RuntimeOrigin::signed(1), test_init_data()),
+					DispatchError::BadOrigin
+				);
+			})
+		}
+
+		#[test]
+		fn init_owner_cannot_initialize_pallet() {
+			run_test(|| {
+				PalletOwner::<TestRuntime>::put(2);
+				assert_noop!(
+					init_with_origin(RuntimeOrigin::signed(2), test_init_data()),
+					DispatchError::BadOrigin
+				);
+			})
+		}
+
+		#[test]
+		fn init_storage_entries_are_correctly_initialized() {
+			run_test(|| {
+				assert_eq!(BestFinalized::<TestRuntime>::get(), None,);
+				assert_eq!(Aleph::best_finalized(), None);
+				assert_eq!(PalletOperatingMode::<TestRuntime>::try_get(), Err(()));
+
+				let init_data = init_with_origin(RuntimeOrigin::root(), test_init_data()).unwrap();
+
+				assert!(<ImportedHeaders<TestRuntime>>::contains_key(init_data.header.hash()));
+				assert_eq!(BestFinalized::<TestRuntime>::get().unwrap().1, init_data.header.hash());
+				assert_eq!(
+					CurrentAuthoritySet::<TestRuntime>::get().authorities,
+					init_data.authority_list
+				);
+				assert_eq!(
+					PalletOperatingMode::<TestRuntime>::try_get(),
+					Ok(BasicOperatingMode::Normal)
+				);
+			})
+		}
+
+		#[test]
+		fn init_can_only_initialize_pallet_once() {
+			run_test(|| {
+				initialize_substrate_bridge();
+				assert_noop!(
+					init_with_origin(RuntimeOrigin::root(), test_init_data()),
+					<Error<TestRuntime>>::AlreadyInitialized
+				);
+			})
+		}
+
+		#[test]
+		fn init_fails_if_there_are_too_many_authorities_in_the_set() {
+			run_test(|| {
+				let genesis = test_header(0);
+				let init_data = InitializationData {
+				header: Box::new(genesis),
+				authority_list: into_authority_set(
+					(0..(<<TestRuntime as Config>::BridgedChain as ChainWithAleph>::MAX_AUTHORITIES_COUNT as u16) + 1).map(|x| Account(x)).collect(),
+				),
+				operating_mode: BasicOperatingMode::Normal,
+			};
+
+				assert_noop!(
+					Aleph::initialize(RuntimeOrigin::root(), init_data),
+					Error::<TestRuntime>::TooManyAuthoritiesInSet,
+				);
+			});
+		}
+
+		#[test]
+		fn parse_finalized_storage_accepts_valid_proof() {
+			run_test(|| {
+				let (state_root, storage_proof) = UnverifiedStorageProof::try_from_entries::<
+					sp_core::Blake2Hasher,
+				>(Default::default(), &[(b"key1".to_vec(), None)])
+				.expect("UnverifiedStorageProof::try_from_entries() shouldn't fail in tests");
+
+				let mut header = test_header(2);
+				header.set_state_root(state_root);
+
+				let hash = header.hash();
+				<BestFinalized<TestRuntime>>::put(HeaderId(2, hash));
+				<ImportedHeaders<TestRuntime>>::insert(hash, header.build());
+
+				assert_ok!(Aleph::verify_storage_proof(hash, storage_proof).map(|_| ()));
+			});
+		}
+
+		#[test]
+		fn storage_keys_computed_properly() {
+			assert_eq!(
+				PalletOperatingMode::<TestRuntime>::storage_value_final_key().to_vec(),
+				bp_header_chain::storage_keys::pallet_operating_mode_key("Aleph").0,
+			);
+
+			assert_eq!(
+				CurrentAuthoritySet::<TestRuntime>::storage_value_final_key().to_vec(),
+				bp_header_chain::storage_keys::current_authority_set_key("Aleph").0,
+			);
+
+			assert_eq!(
+				BestFinalized::<TestRuntime>::storage_value_final_key().to_vec(),
+				bp_header_chain::storage_keys::best_finalized_key("Aleph").0,
+			);
+		}
+
+		#[test]
+		fn insert_header_simple() {
+			run_test(|| {
+				initialize_substrate_bridge();
+
+				let header = test_header(1);
+				let hash = header.hash();
+
+				Aleph::insert_header(header.clone());
+				assert_eq!(<ImportedHeaders<TestRuntime>>::get(hash), Some(header.build()));
+			})
+		}
+
+		#[test]
+		fn insert_header_pruning() {
+			run_test(|| {
+				initialize_substrate_bridge();
+				let headers_to_keep = <TestRuntime as Config>::HeadersToKeep::get();
+
+				for i in 0..2 * headers_to_keep {
+					let header = test_header(i as u64);
+					Aleph::insert_header(header.clone());
+				}
+
+				assert_eq!(
+					ImportedHeaders::<TestRuntime>::iter().count(),
+					headers_to_keep as usize
+				);
+
+				for i in 0..headers_to_keep {
+					let header = test_header(i as u64);
+					assert!(!<ImportedHeaders<TestRuntime>>::contains_key(header.hash()));
+				}
+
+				for i in headers_to_keep..2 * headers_to_keep {
+					let header = test_header(i as u64);
+					let hash = header.hash();
+					assert!(<ImportedHeaders<TestRuntime>>::contains_key(header.hash()));
+					assert_eq!(<ImportedHeaders<TestRuntime>>::get(hash), Some(header.build()));
+				}
+			})
+		}
+
+		// Some tests with "real-life" data
+		// Best case these were testnet/mainnet blocks, but there are no needed digests there yet,
+		// so we use data from local devnet
+		const FIRST_RAW_DEVNET_AUTHORITY_SET: [&str; 4] = [
+			"11bf91f48b4e2d71fb33e4690e427ed12e989a9d9adea06ab18cacd7ea859a29",
+			"09a63b4c82345fac9594b7e0ccfc007983f8be6e75de1fe52e7d1d083b9d8efd",
+			"4002cbce061068c7e090124116e3d3e8a489fc8e78889ed530db385b72a7e733",
+			"40d67c86151aec6be972125a9330c4b385ad6faf6f5caacbe5c9c52259df5cff",
+		];
+
+		// It's devnet so only reorder
+		const SECOND_RAW_DEVNET_AUTHORITY_SET: [&str; 4] = [
+			"40d67c86151aec6be972125a9330c4b385ad6faf6f5caacbe5c9c52259df5cff",
+			"11bf91f48b4e2d71fb33e4690e427ed12e989a9d9adea06ab18cacd7ea859a29",
+			"09a63b4c82345fac9594b7e0ccfc007983f8be6e75de1fe52e7d1d083b9d8efd",
+			"4002cbce061068c7e090124116e3d3e8a489fc8e78889ed530db385b72a7e733",
+		];
+
+		// Block in old session
+		fn devnet_header_and_justification_1() -> (AuthoritySet, TestHeader, AlephJustification) {
+			(
+			raw_authorities_into_authority_set(&FIRST_RAW_DEVNET_AUTHORITY_SET),
+			Header::new(
+			67,
+			decode_from_hex("5076726bb7e9891769edee00786fc7198c8342571f536ec2cad6ad70070a2d4a"),
+			decode_from_hex("107c5dbfafd10aabfb58858aa638d79f3c271bc01c07807c810eb5a68f618397"),
+			decode_from_hex("6a6dafa93280b8ca231c8101506526f385a348a89399abbee19454c5204dbf11"), 
+			Digest {
+				logs: vec![
+				DigestItem::PreRuntime(AURA_ENGINE_ID, FromHex::from_hex("0dd4a66400000000").unwrap()), 
+				DigestItem::Seal(AURA_ENGINE_ID, FromHex::from_hex("2204ea168b79d00d57d54ecd4c8e43318a9dd7a6d438bd4dedc9f3048c6fd626de3d0bdd67a2986e82b100895ba263a9f98eb907560c16aa5a896e0ef723778c").unwrap())
+			]}
+			),
+			aleph_justification_from_hex("0300c60000100001d21a34871a5cadd58acf9f25bbac2fed401a9e74a468a62713e3dd6b9a08fef28c11ceb90e6f2ab83b8ef41cf00aff649c7815d555b4864c4093dd67ce2d8b080183834ada5c662c1237893ec1ee73fc0eb7de63dfaf4353b7677e02355b128d09be7eb0b2f73ee086131296aa7f668af9bf4ae063bebfe9bfeade0a988ff56709013ef0131b3164341c225091e7c3cdb1c069e4a0a6cf7a1fcb0576f18b6194bf3112bbbee7dc111093be93c945386b558448e3b7dee17a3652d567d39163db0605")
+		)
+		}
+
+		// Block with authority set change
+		fn devnet_header_and_justification_2() -> (AuthoritySet, TestHeader, AlephJustification) {
+			(
+			raw_authorities_into_authority_set(&FIRST_RAW_DEVNET_AUTHORITY_SET),
+			Header::new(
+			89,
+			decode_from_hex("c1321ba69772a314d049d0afae0b67399ba738ee4c2c54e5e4162e8e9b6d5950"),
+			decode_from_hex("c768176add8e5ec8d6b480267322990a8b7ad3cbf73d89567a2aec099c671338"),
+			decode_from_hex("1f3b80b9e560fbecac1191c7ba45555bcba13211a6c9fcc78ab861a92a12e08c"), 
+			Digest {
+				logs: vec![
+				DigestItem::PreRuntime(AURA_ENGINE_ID, FromHex::from_hex("23d4a66400000000").unwrap()), 
+				DigestItem::Consensus(ALEPH_ENGINE_ID, FromHex::from_hex("011040d67c86151aec6be972125a9330c4b385ad6faf6f5caacbe5c9c52259df5cff11bf91f48b4e2d71fb33e4690e427ed12e989a9d9adea06ab18cacd7ea859a2909a63b4c82345fac9594b7e0ccfc007983f8be6e75de1fe52e7d1d083b9d8efd4002cbce061068c7e090124116e3d3e8a489fc8e78889ed530db385b72a7e733").unwrap()),
+				DigestItem::Seal(AURA_ENGINE_ID, FromHex::from_hex("4ac4d2960b601fface5822bc14a330ed1537da4b1fed746f9d33b9c3fe39724ff7ef7b9d17278b1bde49fe2be87469a5bd3521b3b8b1d9c67867eeaa78977f8d").unwrap())
+			]}
+			),
+			aleph_justification_from_hex("0300c600001001af459ef570e50fd2ed66782d8f748ed6d168b13fb18573b308c3a8394b0925a135dae4027dc429d20e1f876424d5587b8c6f44b0cd151a3d64e6e11def0e9f0700017883bbbfca6151d66f0dc8f7bce09f80996170e45759054ad00e66aee9165c67dde33065a9c2901d90f78b1cbf525fdc34af8ffbb5cb047da7f4865242aacb02018dc0ea01007e7b532f8f4346ead3a8418c7ed3984d94e66029120fedda4107f4757617f816cddfe188e95844d20733851e25ac3c0f87ed25a990704095dfb508")
+		)
+		}
+
+		// Block in new session
+		fn devnet_header_and_justification_3() -> (AuthoritySet, TestHeader, AlephJustification) {
+			(
+			raw_authorities_into_authority_set(&SECOND_RAW_DEVNET_AUTHORITY_SET),
+			Header::new(
+			110,
+			decode_from_hex("dbc61ebc503528f4a604837267e15c05c954da7cddd819e435f4dceeceb4fec3"),
+			decode_from_hex("1578c9b389cbbf8c01ec0617fe6c6c74f515f3d3c02160bd1f1eff78efea1a41"),
+			decode_from_hex("02c6cff666769bcfe0d41d39915e9f2d5a7007c85b285e11f85a9e36b6d7456c"), 
+			Digest {
+				logs: vec![
+				DigestItem::PreRuntime(AURA_ENGINE_ID, FromHex::from_hex("38d4a66400000000").unwrap()), 
+				DigestItem::Seal(AURA_ENGINE_ID, FromHex::from_hex("369c0862010710603e91c024bc3ecdf0a4de082e364cfe8569643332b177df069441220a457ececde41f7a4740679de289b85f632ad161f2671101f2551a0b8a").unwrap())
+			]}
+			),
+			aleph_justification_from_hex("0300c6000010016ab9f905b9a9d3d19d61165e58998b9c774066e14cff2f3fccb0eac86c497645aacebc33c0ca9df45f11ffcf41c8d308ba414d3462ef8b3374bc6d0d7976a705013aebdf2ea618c094962a7180b2da31b738f36abf1aef3d2e63693f736a934c927c8959aec8b451700c2d503d2bbc89e9ab1db9211c27b7ad949701441fc5c1060001d060b064a4cb27991084f5ea84504a429178b0846420d44a990a249b2db7d918c410a97091d79e6aeab773a99f292ff4f798012af0b97fd0d559019e462a2e05")
+		)
+		}
+
+		#[test]
+		fn accepts_devnet_justification() {
+			run_test(|| {
+				let (init_authority_set, init_header, _justification) =
+					devnet_header_and_justification_1();
+				initialize_with_custom_data(InitializationData {
+					authority_list: init_authority_set,
+					header: Box::new(init_header),
+					operating_mode: BasicOperatingMode::Normal,
+				});
+
+				let (_authority_set, header, justification) = devnet_header_and_justification_2();
+				assert_ok!(Aleph::submit_finality_proof(
+					RuntimeOrigin::signed(1),
+					header,
+					justification
+				));
+			})
+		}
+
+		#[test]
+		fn finds_authority_change_log() {
+			let (_, header, _) = devnet_header_and_justification_2();
+			assert!(get_authority_change(&header.digest()).is_some());
+		}
+
+		#[test]
+		fn accepts_devnet_justifications_with_authority_change() {
+			run_test(|| {
+				let (init_authority_set, init_header, _justification) =
+					devnet_header_and_justification_1();
+				initialize_with_custom_data(InitializationData {
+					authority_list: init_authority_set,
+					header: Box::new(init_header),
+					operating_mode: BasicOperatingMode::Normal,
+				});
+
+				let (_authority_set, header, justification) = devnet_header_and_justification_2();
+				assert_ok!(Aleph::submit_finality_proof(
+					RuntimeOrigin::signed(1),
+					header,
+					justification
+				));
+
+				let (_authority_set_2, header_2, justification_2) =
+					devnet_header_and_justification_3();
+				assert_ok!(Aleph::submit_finality_proof(
+					RuntimeOrigin::signed(1),
+					header_2,
+					justification_2
+				));
+			})
+		}
+
+		#[test]
+		fn rejects_justification_with_old_authority_set() {
+			run_test(|| {
+				let (init_authority_set, init_header, _justification) =
+					devnet_header_and_justification_1();
+				initialize_with_custom_data(InitializationData {
+					authority_list: init_authority_set,
+					header: Box::new(init_header),
+					operating_mode: BasicOperatingMode::Normal,
+				});
+
+				let (_authority_set, header, justification) = devnet_header_and_justification_3();
+				assert_noop!(
+				Aleph::submit_finality_proof(RuntimeOrigin::signed(1), header, justification),
+				Error::<TestRuntime>::InvalidJustification(
+					bp_aleph_header_chain::aleph_justification::Error::NotEnoughCorrectSignatures
+				)
+			);
+			})
+		}
+
+		#[test]
+		fn rejects_old_headers() {
+			run_test(|| {
+				let (init_authority_set, init_header, _justification) =
+					devnet_header_and_justification_2();
+				initialize_with_custom_data(InitializationData {
+					authority_list: init_authority_set,
+					header: Box::new(init_header),
+					operating_mode: BasicOperatingMode::Normal,
+				});
+
+				let (_authority_set, header, justification) = devnet_header_and_justification_1();
+				assert_noop!(
+					Aleph::submit_finality_proof(RuntimeOrigin::signed(1), header, justification),
+					Error::<TestRuntime>::OldHeader
+				);
+
+				assert_eq!(
+					Aleph::best_finalized_number(),
+					Some(devnet_header_and_justification_2().1.number)
+				);
+			})
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	/// Get the best finalized block number.
+	pub fn best_finalized_number() -> Option<BridgedBlockNumber<T>> {
+		BestFinalized::<T>::get().map(|id| id.number())
+	}
+}
+
+/// Bridge Aleph pallet as header chain.
+pub type AlephChainHeaders<T> = Pallet<T>;
+
+impl<T: Config> HeaderChain<BridgedChain<T>> for AlephChainHeaders<T> {
+	fn finalized_header_state_root(
+		header_hash: HashOf<BridgedChain<T>>,
+	) -> Option<HashOf<BridgedChain<T>>> {
+		ImportedHeaders::<T>::get(header_hash).map(|h| h.state_root)
+	}
+}

--- a/pallet-bridge-aleph/src/mock.rs
+++ b/pallet-bridge-aleph/src/mock.rs
@@ -1,0 +1,142 @@
+// Copyright 2023 Cardinal Cryptography
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Structs and utilities for testing.
+//!
+//! Provides a `TestRuntime`, containing the Aleph bridge pallet,
+//! that can be used in tests instead of an actual runtime.
+
+use bp_aleph_header_chain::ChainWithAleph;
+use bp_runtime::{Chain, ChainId};
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{ConstU32, ConstU64, Hooks},
+	weights::Weight,
+	StateVersion,
+};
+use sp_core::sr25519::Signature;
+use sp_runtime::{
+	testing::{Header, H256},
+	traits::{BlakeTwo256, IdentityLookup},
+};
+
+pub type AccountId = u64;
+pub type TestHeader = crate::BridgedHeader<TestRuntime>;
+pub type TestNumber = crate::BridgedBlockNumber<TestRuntime>;
+
+type Block = frame_system::mocking::MockBlock<TestRuntime>;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
+
+use crate as aleph;
+
+construct_runtime! {
+	pub enum TestRuntime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Aleph: aleph::{Pallet, Call, Event<T>},
+	}
+}
+
+impl frame_system::Config for TestRuntime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type Index = u64;
+	type RuntimeCall = RuntimeCall;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
+	type SystemWeightInfo = ();
+	type DbWeight = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+	pub const HeadersToKeep: u32 = 5;
+}
+
+impl aleph::Config for TestRuntime {
+	type RuntimeEvent = RuntimeEvent;
+	type BridgedChain = TestBridgedChain;
+	type HeadersToKeep = HeadersToKeep;
+}
+
+#[derive(Debug)]
+pub struct TestBridgedChain;
+
+impl Chain for TestBridgedChain {
+	const ID: ChainId = *b"talp";
+
+	type BlockNumber = <TestRuntime as frame_system::Config>::BlockNumber;
+	type Hash = <TestRuntime as frame_system::Config>::Hash;
+	type Hasher = <TestRuntime as frame_system::Config>::Hashing;
+	type Header = <TestRuntime as frame_system::Config>::Header;
+
+	type AccountId = AccountId;
+	type Balance = u64;
+	type Index = u64;
+	type Signature = Signature;
+
+	const STATE_VERSION: StateVersion = StateVersion::V1;
+
+	fn max_extrinsic_size() -> u32 {
+		unreachable!()
+	}
+	fn max_extrinsic_weight() -> Weight {
+		unreachable!()
+	}
+}
+
+impl ChainWithAleph for TestBridgedChain {
+	const WITH_CHAIN_ALEPH_PALLET_NAME: &'static str = "";
+	const MAX_AUTHORITIES_COUNT: u32 = 5;
+}
+
+/// Return test externalities to use in tests.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	sp_io::TestExternalities::new(Default::default())
+}
+
+/// Return test within default test externalities context.
+pub fn run_test<T>(test: impl FnOnce() -> T) -> T {
+	new_test_ext().execute_with(|| {
+		let _ = Aleph::on_initialize(0);
+		test()
+	})
+}
+
+/// Return test header with given number.
+pub fn test_header(num: TestNumber) -> TestHeader {
+	// We wrap the call to avoid explicit type annotations in our tests
+	bp_test_utils::test_header(num)
+}

--- a/pallet-bridge-aleph/src/storage_types.rs
+++ b/pallet-bridge-aleph/src/storage_types.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 Cardinal Cryptography
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Wrappers for public types that are implementing `MaxEncodedLen`
+
+use crate::{Config, Error};
+
+use bp_aleph_header_chain::{AuthorityId, AuthoritySet, ChainWithAleph};
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{traits::Get, BoundedVec, RuntimeDebugNoBound};
+use scale_info::TypeInfo;
+
+use sp_std::marker::PhantomData;
+
+pub struct MaxAuthoritiesCount<T: Config>(PhantomData<T>);
+
+impl<T: Config> Get<u32> for MaxAuthoritiesCount<T> {
+	fn get() -> u32 {
+		T::BridgedChain::MAX_AUTHORITIES_COUNT
+	}
+}
+
+/// Bounded AlephBFT Authority Set.
+#[derive(Clone, Decode, Encode, TypeInfo, MaxEncodedLen, RuntimeDebugNoBound)]
+#[scale_info(skip_type_params(T))]
+pub struct StoredAuthoritySet<T: Config> {
+	/// List of AlephBFT authorities for the current session.
+	pub authorities: BoundedVec<AuthorityId, MaxAuthoritiesCount<T>>,
+}
+
+impl<T: Config> StoredAuthoritySet<T> {
+	/// Try to create a new bounded AlephBFT Authority Set from unbounded list.
+	///
+	/// Returns error if number of authorities in the provided list is too large.
+	pub fn try_new(authorities: AuthoritySet) -> Result<Self, Error<T>> {
+		Ok(Self {
+			authorities: TryFrom::try_from(authorities)
+				.map_err(|_| Error::TooManyAuthoritiesInSet)?,
+		})
+	}
+}
+
+impl<T: Config> Default for StoredAuthoritySet<T> {
+	fn default() -> Self {
+		Self { authorities: BoundedVec::default() }
+	}
+}
+
+impl<T: Config> From<StoredAuthoritySet<T>> for AuthoritySet {
+	fn from(t: StoredAuthoritySet<T>) -> Self {
+		t.authorities.into()
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
@@ -26,58 +26,56 @@ scale-info = { version = "2.4.0", default-features = false, features = [
 smallvec = "1.10.0"
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
-pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master" }
+pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 # Polkadot
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.40" }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
 
 # Cumulus
-cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false, version = "3.0.0" }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-pallet-collator-selection = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
-parachain-info = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.40", default-features = false }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false, version = "3.0.0" }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+pallet-collator-selection = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+parachain-info = { git = "https://github.com/paritytech/cumulus.git", branch = "master", default-features = false }
+
+# Bridge dependencies
+pallet-bridge-aleph = { path = "../pallet-bridge-aleph", default-features = false }
 
 [features]
 default = ["std"]
@@ -101,17 +99,13 @@ std = [
 	"pallet-aura/std",
 	"pallet-authorship/std",
 	"pallet-balances/std",
+	"pallet-bridge-aleph/std",
 	"pallet-collator-selection/std",
-	"pallet-multisig/std",
-	"pallet-preimage/std",
-	"pallet-proxy/std",
-	"pallet-scheduler/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
-	"pallet-utility/std",
 	"pallet-xcm/std",
 	"parachain-info/std",
 	"polkadot-parachain/std",
@@ -161,14 +155,10 @@ try-runtime = [
 	"pallet-authorship/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-collator-selection/try-runtime",
-	"pallet-multisig/try-runtime",
-	"pallet-preimage/try-runtime",
-	"pallet-proxy/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
-	"pallet-utility/try-runtime",
 	"pallet-xcm/try-runtime",
 	"parachain-info/try-runtime",
 ]

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -5,21 +5,25 @@ use super::{
 use core::{marker::PhantomData, ops::ControlFlow};
 use frame_support::{
 	log, match_types, parameter_types,
-	traits::{ConstU32, Everything, Nothing},
+	traits::{ConstU32, Everything, Nothing, ProcessMessageError},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
-use xcm::{latest::prelude::*, CreateMatcher, MatchXcm};
+use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowTopLevelPaidExecutionFrom,
-	CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds, IsConcrete, NativeAsset, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
-	UsingComponents, WithComputedOrigin,
+	CreateMatcher, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds, IsConcrete, MatchXcm,
+	NativeAsset, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents, WithComputedOrigin,
 };
-use xcm_executor::{traits::ShouldExecute, XcmExecutor};
+use xcm_executor::{
+	traits::{Properties, ShouldExecute},
+	XcmExecutor,
+};
 
 parameter_types! {
 	pub const RelayLocation: MultiLocation = MultiLocation::parent();
@@ -106,10 +110,10 @@ where
 		origin: &MultiLocation,
 		message: &mut [Instruction<RuntimeCall>],
 		max_weight: Weight,
-		weight_credit: &mut Weight,
-	) -> Result<(), ()> {
-		Deny::should_execute(origin, message, max_weight, weight_credit)?;
-		Allow::should_execute(origin, message, max_weight, weight_credit)
+		properties: &mut Properties,
+	) -> Result<(), ProcessMessageError> {
+		Deny::should_execute(origin, message, max_weight, properties)?;
+		Allow::should_execute(origin, message, max_weight, properties)
 	}
 }
 
@@ -120,8 +124,8 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 		origin: &MultiLocation,
 		message: &mut [Instruction<RuntimeCall>],
 		_max_weight: Weight,
-		_weight_credit: &mut Weight,
-	) -> Result<(), ()> {
+		_properties: &mut Properties,
+	) -> Result<(), ProcessMessageError> {
 		message.matcher().match_next_inst_while(
 			|_| true,
 			|inst| match inst {
@@ -135,7 +139,7 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 				TransferReserveAsset {
 					dest: MultiLocation { parents: 1, interior: Here }, ..
 				} => {
-					Err(()) // Deny
+					Err(ProcessMessageError::Unsupported) // Deny
 				},
 				// An unexpected reserve transfer has arrived from the Relay Chain. Generally,
 				// `IsReserve` should not allow this, but we just log it here.
@@ -182,6 +186,7 @@ impl xcm_executor::Config for XcmConfig {
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = NativeAsset;
 	type IsTeleporter = (); // Teleporting is disabled.
+	type Aliasers = ();
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
@@ -220,6 +225,7 @@ parameter_types! {
 }
 
 impl pallet_xcm::Config for Runtime {
+	type AdminOrigin = EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmRouter = XcmRouter;
@@ -246,6 +252,8 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type MaxRemoteLockConsumers = ConstU32<0>;
+	type RemoteLockConsumerIdentifier = ();
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,5 @@
 [toolchain]
-channel = "nightly-2023-01-01"
-components = [ "rustfmt", "rust-src", "clippy" ]
+channel = "nightly-2023-06-01"
+components = [ "clippy", "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"
-


### PR DESCRIPTION
This integrates:

https://github.com/Cardinal-Cryptography/aleph-parachain-bridge/pull/2 
https://github.com/Cardinal-Cryptography/aleph-parachain-bridge/pull/5
https://github.com/Cardinal-Cryptography/aleph-parachain-bridge/pull/6

without having all of the dependencies copied into the repo, they are pulled in from https://github.com/paritytech/parity-bridges-common instead. The only thing I had to remove for now was the `set_block_number` function, as it required changes in `bp_header_chain` - I hope we can find another way to have that functionality.

Closes A0-2548
Closes A0-2549
Closes A0-2550